### PR TITLE
feat: allow defining fallback configuration key

### DIFF
--- a/gravitee-exchange-api/src/test/java/io/gravitee/exchange/api/configuration/IdentifyConfigurationTest.java
+++ b/gravitee-exchange-api/src/test/java/io/gravitee/exchange/api/configuration/IdentifyConfigurationTest.java
@@ -17,6 +17,7 @@ package io.gravitee.exchange.api.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -63,6 +64,12 @@ class IdentifyConfigurationTest {
         void should_get_property() {
             environment.withProperty("exchange.key", "value");
             assertThat(cut.getProperty("key")).isEqualTo("value");
+        }
+
+        @Test
+        void should_get_property_list() {
+            environment.withProperty("exchange.key[0]", "value");
+            assertThat(cut.getPropertyList("key")).containsOnly("value");
         }
 
         @Test
@@ -120,6 +127,12 @@ class IdentifyConfigurationTest {
         }
 
         @Test
+        void should_get_property_list() {
+            environment.withProperty("custom.key[0]", "value");
+            assertThat(cut.getPropertyList("key")).containsOnly("value");
+        }
+
+        @Test
         void should_not_get_property_with_wrong_prefix() {
             environment.withProperty("wrong.key", "value");
             assertThat(cut.getProperty("key")).isNull();
@@ -144,6 +157,45 @@ class IdentifyConfigurationTest {
         @Test
         void should_return_identify_name() {
             assertThat(cut.identifyName("name")).isEqualTo("custom-name");
+        }
+    }
+
+    @Nested
+    class FallbackKeys {
+
+        @BeforeEach
+        public void beforeEach() {
+            cut = new IdentifyConfiguration(environment, Map.of("key", "fallbackKey", "collectionKey", "fallbackCollectionKey"));
+        }
+
+        @Test
+        void should_contain_property() {
+            environment.withProperty("fallbackKey", "value");
+            assertThat(cut.containsProperty("key")).isTrue();
+        }
+
+        @Test
+        void should_get_property() {
+            environment.withProperty("fallbackKey", "value");
+            assertThat(cut.getProperty("key")).isEqualTo("value");
+        }
+
+        @Test
+        void should_get_property_list() {
+            environment.withProperty("fallbackCollectionKey[0]", "value");
+            assertThat(cut.getPropertyList("collectionKey")).containsOnly("value");
+        }
+
+        @Test
+        void should_not_get_property_with_wrong_prefix() {
+            environment.withProperty("wrong.fallbackKey", "value");
+            assertThat(cut.getProperty("key")).isNull();
+        }
+
+        @Test
+        void should_get_custom_property() {
+            environment.withProperty("fallbackKey", "123");
+            assertThat(cut.getProperty("key", Integer.class, 0)).isEqualTo(123);
         }
     }
 }

--- a/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/client/WebSocketClientConfiguration.java
+++ b/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/client/WebSocketClientConfiguration.java
@@ -153,19 +153,12 @@ public class WebSocketClientConfiguration {
     }
 
     private List<WebSocketEndpoint> readEndpoints() {
-        int endpointIndex = 0;
-        String key = ("%s[%s]").formatted(ENDPOINTS_KEY, endpointIndex);
         List<WebSocketEndpoint> endpointsConfiguration = new ArrayList<>();
-
-        while (identifyConfiguration.containsProperty(key)) {
-            String url = identifyConfiguration.getProperty(key);
-            if (url != null && !url.isBlank()) {
-                endpointsConfiguration.add(new WebSocketEndpoint(url, maxRetry()));
-            }
-            endpointIndex++;
-            key = ("%s[%s]").formatted(ENDPOINTS_KEY, endpointIndex);
+        List<String> propertyList = identifyConfiguration.getPropertyList(ENDPOINTS_KEY);
+        if (propertyList != null) {
+            int maxRetryCount = maxRetry();
+            endpointsConfiguration.addAll(propertyList.stream().map(url -> new WebSocketEndpoint(url, maxRetryCount)).toList());
         }
-
         return endpointsConfiguration;
     }
 }


### PR DESCRIPTION
**Description**

Add builtin mechanism in order to define fallback key for the new configuration. This will avoid any breaking change on cockpit connector.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0-support-deprecated-keys-configuration-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/exchange/gravitee-exchange/1.0.0-support-deprecated-keys-configuration-SNAPSHOT/gravitee-exchange-1.0.0-support-deprecated-keys-configuration-SNAPSHOT.zip)
  <!-- Version placeholder end -->
