### PR TITLE
chore: update job name for build & release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ workflows:
         when:
             not: << pipeline.git.tag >>
         jobs:
-            - gravitee/setup_plugin-build-config:
+            - gravitee/setup_lib-build-config:
                   filters:
                       tags:
                           ignore:
@@ -25,7 +25,7 @@ workflows:
                 pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
                 value: << pipeline.git.tag >>
         jobs:
-            - gravitee/setup_plugin-release-config:
+            - gravitee/setup_lib-release-config:
                   filters:
                       branches:
                           ignore:


### PR DESCRIPTION
**Description**

Using the right Orbs jobs for release and build: this repository contains a library and not a gravitee plugin.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.1`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/exchange/gravitee-exchange/1.0.1/gravitee-exchange-1.0.1.zip)
  <!-- Version placeholder end -->
