### PR TITLE
fix: adapt GoodByeCommand for legacy protocol

### DIFF
--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/protocol/legacy/goodbye/GoodyeCommandAdapter.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/protocol/legacy/goodbye/GoodyeCommandAdapter.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.exchange.api.websocket.protocol.legacy.goodbye;
 
+import io.gravitee.exchange.api.channel.exception.ChannelClosedException;
 import io.gravitee.exchange.api.command.CommandAdapter;
 import io.gravitee.exchange.api.command.goodbye.GoodByeReply;
 import io.reactivex.rxjava3.core.Single;
@@ -33,6 +34,13 @@ public class GoodyeCommandAdapter
 
     @Override
     public Single<GoodByeCommand> adapt(final io.gravitee.exchange.api.command.goodbye.GoodByeCommand command) {
-        return Single.just(new GoodByeCommand(command.getId()));
+        return Single.fromCallable(() -> {
+            // The legacy protocol doesn't support reconnect option, we ignore the command to generate a websocket.close()
+            // from the controller instead of doing it on controller.
+            if (command.getPayload().isReconnect()) {
+                throw new ChannelClosedException();
+            }
+            return new GoodByeCommand(command.getId());
+        });
     }
 }

--- a/gravitee-exchange-connector/gravitee-exchange-connector-core/src/main/java/io/gravitee/exchange/connector/core/DefaultExchangeConnectorManager.java
+++ b/gravitee-exchange-connector/gravitee-exchange-connector-core/src/main/java/io/gravitee/exchange/connector/core/DefaultExchangeConnectorManager.java
@@ -15,9 +15,6 @@
  */
 package io.gravitee.exchange.connector.core;
 
-import io.gravitee.exchange.api.command.goodbye.GoodByeCommand;
-import io.gravitee.exchange.api.command.healtcheck.HealthCheckCommand;
-import io.gravitee.exchange.api.command.primary.PrimaryCommand;
 import io.gravitee.exchange.api.connector.ExchangeConnector;
 import io.gravitee.exchange.api.connector.ExchangeConnectorManager;
 import io.gravitee.exchange.connector.core.command.goodbye.GoodByeCommandHandler;


### PR DESCRIPTION
**Description**

With legacy protocol, the goodbye command with a reconnect:true should be ignored. Instead a Exception is thrown and then capture by the controller which lead to a websocket close.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.2-adapt-goodbye-command-for-legacy-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/exchange/gravitee-exchange/1.0.2-adapt-goodbye-command-for-legacy-SNAPSHOT/gravitee-exchange-1.0.2-adapt-goodbye-command-for-legacy-SNAPSHOT.zip)
  <!-- Version placeholder end -->
