### PR TITLE
feat: improve handshake error handling

### DIFF
--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/controller/ControllerCommandHandlersFactory.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/controller/ControllerCommandHandlersFactory.java
@@ -40,19 +40,23 @@ public interface ControllerCommandHandlersFactory {
      * @param controllerCommandContext the command context
      * @return a list of command decorators
      */
-    List<CommandAdapter<? extends Command<?>, ? extends Command<?>, ? extends Reply<?>>> buildCommandAdapters(
+    default List<CommandAdapter<? extends Command<?>, ? extends Command<?>, ? extends Reply<?>>> buildCommandAdapters(
         final ControllerCommandContext controllerCommandContext,
         final ProtocolVersion protocolVersion
-    );
+    ) {
+        return List.of();
+    }
 
     /**
-     * Build a list of command decorators dedicated to the specified context.
+     * Build a list of reply decorators dedicated to the specified context.
      *
      * @param controllerCommandContext the command context
-     * @return a list of command decorators
+     * @return a list of reply decorators
      */
-    List<ReplyAdapter<? extends Reply<?>, ? extends Reply<?>>> buildReplyAdapters(
+    default List<ReplyAdapter<? extends Reply<?>, ? extends Reply<?>>> buildReplyAdapters(
         final ControllerCommandContext controllerCommandContext,
         final ProtocolVersion protocolVersion
-    );
+    ) {
+        return List.of();
+    }
 }

--- a/gravitee-exchange-connector/gravitee-exchange-connector-core/src/main/java/io/gravitee/exchange/connector/core/DefaultExchangeConnectorManager.java
+++ b/gravitee-exchange-connector/gravitee-exchange-connector-core/src/main/java/io/gravitee/exchange/connector/core/DefaultExchangeConnectorManager.java
@@ -68,7 +68,9 @@ public class DefaultExchangeConnectorManager implements ExchangeConnectorManager
     public Completable unregister(final ExchangeConnector exchangeConnector) {
         return Completable
             .defer(() -> {
-                exchangeConnectors.remove(exchangeConnector.targetId(), exchangeConnector);
+                if (exchangeConnector.targetId() != null) {
+                    exchangeConnectors.remove(exchangeConnector.targetId(), exchangeConnector);
+                }
                 return exchangeConnector.close();
             })
             .doOnComplete(() -> log.debug("Connector successfully unregister for target [{}]", exchangeConnector.targetId()))

--- a/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/WebSocketExchangeConnector.java
+++ b/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/WebSocketExchangeConnector.java
@@ -92,7 +92,7 @@ public class WebSocketExchangeConnector extends EmbeddedExchangeConnector {
                     if (err instanceof WebSocketConnectorException connectorException && connectorException.isRetryable()) {
                         return Flowable.timer(5000, TimeUnit.MILLISECONDS);
                     }
-                    log.error("Unable to connect to Exchange Connect Endpoint, stop retrying.", err);
+                    log.error("Unable to connect to Exchange Connect Endpoint, stop retrying.");
                     return Flowable.error(err);
                 })
             );

--- a/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/channel/WebSocketConnectorChannel.java
+++ b/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/channel/WebSocketConnectorChannel.java
@@ -16,7 +16,6 @@
 package io.gravitee.exchange.connector.websocket.channel;
 
 import io.gravitee.exchange.api.channel.exception.ChannelException;
-import io.gravitee.exchange.api.channel.exception.ChannelInitializationException;
 import io.gravitee.exchange.api.command.Command;
 import io.gravitee.exchange.api.command.CommandAdapter;
 import io.gravitee.exchange.api.command.CommandHandler;
@@ -75,7 +74,10 @@ public class WebSocketConnectorChannel extends AbstractWebSocketChannel implemen
                                 this.targetId = reply.getPayload().getTargetId();
                                 this.active = true;
                             } else {
-                                throw new ChannelInitializationException("Unable to parse hello reply payload");
+                                throw new WebSocketConnectorException(
+                                    String.format("Hello handshake failed: %s", reply.getErrorDetails()),
+                                    false
+                                );
                             }
                         });
                 })


### PR DESCRIPTION
**Description**

When HelloReply's status is ERROR, throw an exception containing error detail that can be handled by the caller.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.0-improve-handshake-error-handling-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/exchange/gravitee-exchange/1.1.0-improve-handshake-error-handling-SNAPSHOT/gravitee-exchange-1.1.0-improve-handshake-error-handling-SNAPSHOT.zip)
  <!-- Version placeholder end -->
