### PR TITLE
fix: use exponential backoff strategy for reconnection retry

### DIFF
--- a/gravitee-exchange-connector/gravitee-exchange-connector-websocket/pom.xml
+++ b/gravitee-exchange-connector/gravitee-exchange-connector-websocket/pom.xml
@@ -46,6 +46,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.gravitee.common</groupId>
+            <artifactId>gravitee-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
             <scope>provided</scope>
@@ -64,11 +69,6 @@
             <groupId>io.reactivex.rxjava3</groupId>
             <artifactId>rxjava</artifactId>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.gravitee.common</groupId>
-            <artifactId>gravitee-common</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.gravitee.exchange</groupId>

--- a/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/client/WebSocketClientConfiguration.java
+++ b/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/client/WebSocketClientConfiguration.java
@@ -31,8 +31,6 @@ import lombok.RequiredArgsConstructor;
 public class WebSocketClientConfiguration {
 
     public static final String HEADERS_KEY = "connector.ws.headers";
-    public static final String MAX_RETRY_KEY = "connector.ws.maxRetry";
-    public static final int MAX_RETRY_DEFAULT = 5;
     public static final String TRUST_ALL_KEY = "connector.ws.ssl.trustAll";
     public static final boolean TRUST_ALL_DEFAULT = false;
     public static final String VERIFY_HOST_KEY = "connector.ws.ssl.verifyHost";
@@ -74,10 +72,6 @@ public class WebSocketClientConfiguration {
             key = ("%s[%s]").formatted(HEADERS_KEY, endpointIndex);
         }
         return computedHeaders;
-    }
-
-    public int maxRetry() {
-        return identifyConfiguration.getProperty(MAX_RETRY_KEY, Integer.class, MAX_RETRY_DEFAULT);
     }
 
     public boolean trustAll() {
@@ -156,8 +150,7 @@ public class WebSocketClientConfiguration {
         List<WebSocketEndpoint> endpointsConfiguration = new ArrayList<>();
         List<String> propertyList = identifyConfiguration.getPropertyList(ENDPOINTS_KEY);
         if (propertyList != null) {
-            int maxRetryCount = maxRetry();
-            endpointsConfiguration.addAll(propertyList.stream().map(url -> new WebSocketEndpoint(url, maxRetryCount)).toList());
+            endpointsConfiguration.addAll(propertyList.stream().map(WebSocketEndpoint::new).toList());
         }
         return endpointsConfiguration;
     }

--- a/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/client/WebSocketConnectorClientFactory.java
+++ b/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/client/WebSocketConnectorClientFactory.java
@@ -53,21 +53,15 @@ public class WebSocketConnectorClientFactory {
         if (endpoints.isEmpty()) {
             return null;
         }
+        return endpoints.get(Math.abs(counter.getAndIncrement() % endpoints.size()));
+    }
 
-        WebSocketEndpoint endpoint = endpoints.get(Math.abs(counter.getAndIncrement() % endpoints.size()));
+    public void resetEndpointRetries() {
+        counter.set(0);
+    }
 
-        endpoint.incrementRetryCount();
-        if (endpoint.isRemovable()) {
-            log.info(
-                "Websocket Exchange Connector connects to endpoint at {} more than {} times. Removing instance...",
-                endpoint.getUri().toString(),
-                endpoint.getMaxRetryCount()
-            );
-            configuration.endpoints().remove(endpoint);
-            return nextEndpoint();
-        }
-
-        return endpoint;
+    public int endpointRetries() {
+        return counter.get();
     }
 
     public HttpClient createHttpClient(WebSocketEndpoint websocketEndpoint) {

--- a/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/client/WebSocketEndpoint.java
+++ b/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/client/WebSocketEndpoint.java
@@ -29,25 +29,12 @@ public class WebSocketEndpoint {
     private static final String HTTPS_SCHEME = "https";
     private static final int DEFAULT_HTTP_PORT = 80;
     private static final int DEFAULT_HTTPS_PORT = 443;
-    public static final int DEFAULT_MAX_RETRY_COUNT = 5;
 
     private final URI uri;
-    private final int maxRetryCount;
-    private int retryCount;
 
     @Builder
-    public WebSocketEndpoint(final String url, final int maxRetryCount) {
+    public WebSocketEndpoint(final String url) {
         this.uri = URI.create(url);
-        this.maxRetryCount = maxRetryCount > 0 ? maxRetryCount : DEFAULT_MAX_RETRY_COUNT;
-        this.retryCount = 0;
-    }
-
-    public void incrementRetryCount() {
-        this.retryCount++;
-    }
-
-    public void resetRetryCount() {
-        this.retryCount = 0;
     }
 
     public int getPort() {
@@ -66,9 +53,5 @@ public class WebSocketEndpoint {
 
     public String resolvePath(String path) {
         return uri.resolve(path).getRawPath();
-    }
-
-    public boolean isRemovable() {
-        return this.retryCount > maxRetryCount;
     }
 }

--- a/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/test/java/io/gravitee/exchange/connector/websocket/client/WebSocketClientConfigurationTest.java
+++ b/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/test/java/io/gravitee/exchange/connector/websocket/client/WebSocketClientConfigurationTest.java
@@ -73,17 +73,6 @@ class WebSocketClientConfigurationTest {
         }
 
         @Test
-        void should_return_max_retry() {
-            environment.withProperty("%s.connector.ws.maxRetry".formatted(prefix), "123456");
-            assertThat(cut.maxRetry()).isEqualTo(123456);
-        }
-
-        @Test
-        void should_return_default_max_retry_without_configuration() {
-            assertThat(cut.maxRetry()).isEqualTo(5);
-        }
-
-        @Test
         void should_return_trust_all() {
             environment.withProperty("%s.connector.ws.ssl.trustAll".formatted(prefix), "true");
             assertThat(cut.trustAll()).isTrue();

--- a/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/test/java/io/gravitee/exchange/connector/websocket/client/WebSocketConnectorClientFactoryTest.java
+++ b/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/test/java/io/gravitee/exchange/connector/websocket/client/WebSocketConnectorClientFactoryTest.java
@@ -78,13 +78,15 @@ class WebSocketConnectorClientFactoryTest {
         }
 
         @Test
-        void should_return_null_when_max_retry_reach() {
+        void should_loop_over_endpoint_on_each_next_endpoint() {
             environment.setProperty("exchange.connector.ws.endpoints[0]", "http://endpoint:1234");
-            for (int i = 0; i < WebSocketEndpoint.DEFAULT_MAX_RETRY_COUNT; i++) {
-                cut.nextEndpoint();
-            }
-            WebSocketEndpoint webSocketEndpoint = cut.nextEndpoint();
-            assertThat(webSocketEndpoint).isNull();
+            environment.setProperty("exchange.connector.ws.endpoints[1]", "http://endpoint:5678");
+            WebSocketEndpoint webSocketEndpoint1 = cut.nextEndpoint();
+            WebSocketEndpoint webSocketEndpoint2 = cut.nextEndpoint();
+            WebSocketEndpoint webSocketEndpoint3 = cut.nextEndpoint();
+            assertThat(webSocketEndpoint1.getPort()).isEqualTo(1234);
+            assertThat(webSocketEndpoint2.getPort()).isEqualTo(5678);
+            assertThat(webSocketEndpoint3.getPort()).isEqualTo(1234);
         }
 
         @Test

--- a/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/test/java/io/gravitee/exchange/connector/websocket/client/WebSocketEndpointTest.java
+++ b/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/test/java/io/gravitee/exchange/connector/websocket/client/WebSocketEndpointTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -47,51 +46,15 @@ class WebSocketEndpointTest {
     @ParameterizedTest
     @MethodSource("urls")
     void should_create_default_websocket_endpoint(String baseUrl, String host, int port) {
-        WebSocketEndpoint endpoint = new WebSocketEndpoint(baseUrl, -1);
+        WebSocketEndpoint endpoint = new WebSocketEndpoint(baseUrl);
         assertThat(endpoint.getHost()).isEqualTo(host);
         assertThat(endpoint.getPort()).isEqualTo(port);
-        assertThat(endpoint.getMaxRetryCount()).isEqualTo(5);
-        assertThat(endpoint.getRetryCount()).isZero();
     }
 
     @ParameterizedTest
     @MethodSource("urls")
     void should_resolve_path(String baseUrl) {
-        WebSocketEndpoint endpoint = new WebSocketEndpoint(baseUrl, -1);
+        WebSocketEndpoint endpoint = new WebSocketEndpoint(baseUrl);
         assertThat(endpoint.resolvePath("/path")).isEqualTo("/path");
-    }
-
-    @Test
-    void should_create_websocket_endpoint_with_max_retry() {
-        WebSocketEndpoint endpoint = new WebSocketEndpoint("http://localhost:8062", 10);
-        assertThat(endpoint.getMaxRetryCount()).isEqualTo(10);
-        assertThat(endpoint.getRetryCount()).isZero();
-    }
-
-    @Test
-    void should_increment_retry_counter() {
-        WebSocketEndpoint endpoint = new WebSocketEndpoint("http://localhost:8062", -1);
-        assertThat(endpoint.getRetryCount()).isZero();
-        assertThat(endpoint.getMaxRetryCount()).isEqualTo(5);
-        endpoint.incrementRetryCount();
-        assertThat(endpoint.getRetryCount()).isEqualTo(1);
-    }
-
-    @Test
-    void should_resent__retry_counter() {
-        WebSocketEndpoint endpoint = new WebSocketEndpoint("http://localhost:8062", -1);
-        endpoint.incrementRetryCount();
-        assertThat(endpoint.getRetryCount()).isEqualTo(1);
-        endpoint.resetRetryCount();
-        assertThat(endpoint.getRetryCount()).isZero();
-    }
-
-    @Test
-    void should_be_removable_when_retry_is_higher_than_max() {
-        WebSocketEndpoint endpoint = new WebSocketEndpoint("http://localhost:8062", 1);
-        endpoint.incrementRetryCount();
-        assertThat(endpoint.isRemovable()).isFalse();
-        endpoint.incrementRetryCount();
-        assertThat(endpoint.isRemovable()).isTrue();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <gravitee-bom.version>6.0.35</gravitee-bom.version>
-        <gravitee-common.version>3.4.1</gravitee-common.version>
+        <gravitee-common.version>4.2.0</gravitee-common.version>
         <gravitee-node.version>5.10.0</gravitee-node.version>
 
         <commons-lang3.version>3.14.0</commons-lang3.version>


### PR DESCRIPTION
**Description**

Just increase default max retry to 20.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.0-increase-retry-default-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/exchange/gravitee-exchange/1.2.0-increase-retry-default-SNAPSHOT/gravitee-exchange-1.2.0-increase-retry-default-SNAPSHOT.zip)
  <!-- Version placeholder end -->
