### PR TITLE
fix: rework primary channel election

### DIFF
--- a/gravitee-exchange-connector/gravitee-exchange-connector-embedded/src/main/java/io/gravitee/exchange/connector/embedded/EmbeddedExchangeConnector.java
+++ b/gravitee-exchange-connector/gravitee-exchange-connector-embedded/src/main/java/io/gravitee/exchange/connector/embedded/EmbeddedExchangeConnector.java
@@ -23,10 +23,10 @@ import io.gravitee.exchange.api.connector.ExchangeConnector;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Single;
 import java.util.List;
-import java.util.Map;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -34,6 +34,7 @@ import lombok.experimental.SuperBuilder;
  */
 @SuperBuilder
 @NoArgsConstructor
+@Slf4j
 public class EmbeddedExchangeConnector implements ExchangeConnector {
 
     protected ConnectorChannel connectorChannel;
@@ -68,6 +69,7 @@ public class EmbeddedExchangeConnector implements ExchangeConnector {
 
     @Override
     public void setPrimary(final boolean isPrimary) {
+        log.debug("Setting primary status '{}' on connector", isPrimary);
         this.primary = isPrimary;
     }
 
@@ -78,6 +80,8 @@ public class EmbeddedExchangeConnector implements ExchangeConnector {
 
     @Override
     public void addCommandHandlers(final List<CommandHandler<? extends Command<?>, ? extends Reply<?>>> commandHandlers) {
-        this.connectorChannel.addCommandHandlers(commandHandlers);
+        if (this.connectorChannel != null) {
+            this.connectorChannel.addCommandHandlers(commandHandlers);
+        }
     }
 }

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/channel/primary/PrimaryChannelCandidateStore.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/channel/primary/PrimaryChannelCandidateStore.java
@@ -18,29 +18,28 @@ package io.gravitee.exchange.controller.core.channel.primary;
 import io.gravitee.node.api.cache.Cache;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
-import io.reactivex.rxjava3.core.Single;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class PrimaryChannelCandidateStore {
 
-    private final Cache<String, List<String>> store;
+    private final Cache<String, Set<String>> store;
 
-    public Flowable<Map.Entry<String, List<String>>> rxEntries() {
+    public Flowable<Map.Entry<String, Set<String>>> rxEntries() {
         return store.rxEntrySet();
     }
 
-    public Maybe<List<String>> rxGet(final String targetId) {
+    public Maybe<Set<String>> rxGet(final String targetId) {
         if (targetId == null) {
             return Maybe.error(new IllegalArgumentException("Target id cannot be null"));
         }
         return store.rxGet(targetId);
     }
 
-    public List<String> get(final String targetId) {
+    public Set<String> get(final String targetId) {
         if (targetId == null) {
             throw new IllegalArgumentException("Target id cannot be null");
         }
@@ -58,7 +57,7 @@ public class PrimaryChannelCandidateStore {
             targetId,
             (key, channels) -> {
                 if (channels == null) {
-                    return new ArrayList<>(List.of(channelId));
+                    channels = new HashSet<>();
                 }
                 channels.add(channelId);
                 return channels;

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/channel/primary/PrimaryChannelCandidateStoreTest.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/channel/primary/PrimaryChannelCandidateStoreTest.java
@@ -22,7 +22,9 @@ import io.gravitee.node.api.cache.Cache;
 import io.gravitee.node.api.cache.CacheConfiguration;
 import io.gravitee.node.plugin.cache.common.InMemoryCache;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,7 +35,7 @@ import org.junit.jupiter.api.Test;
  */
 class PrimaryChannelCandidateStoreTest {
 
-    private Cache<String, List<String>> store;
+    private Cache<String, Set<String>> store;
     private PrimaryChannelCandidateStore cut;
 
     @BeforeEach
@@ -44,7 +46,7 @@ class PrimaryChannelCandidateStoreTest {
 
     @Test
     void should_get_from_store() {
-        store.put("targetId", List.of("channelId", "channelId2"));
+        store.put("targetId", Set.of("channelId", "channelId2"));
         assertThat(cut.get("targetId")).containsOnly("channelId", "channelId2");
     }
 
@@ -76,14 +78,14 @@ class PrimaryChannelCandidateStoreTest {
 
     @Test
     void should_remove_from_store() {
-        store.put("targetId", new ArrayList<>(List.of("channelId")));
+        store.put("targetId", new HashSet<>(List.of("channelId")));
         cut.remove("targetId", "channelId");
         assertThat(store.containsKey("targetId")).isFalse();
     }
 
     @Test
     void should_remove_only_one_channel_from_store() {
-        store.put("targetId", new ArrayList<>(List.of("channelId", "channelId2")));
+        store.put("targetId", new HashSet<>(List.of("channelId", "channelId2")));
         cut.remove("targetId", "channelId");
         assertThat(store.containsKey("targetId")).isTrue();
         assertThat(store.get("targetId")).containsOnly("channelId2");


### PR DESCRIPTION
**Description**

  - list of candidate was containing duplicating id which could lead to wrong primary election
  - if the primary channel is also present locally, it was first primary then secondary
  - handler on connector was too late registered
  - election topic was badly configured

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.1-fix-primary-election-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/exchange/gravitee-exchange/1.2.1-fix-primary-election-SNAPSHOT/gravitee-exchange-1.2.1-fix-primary-election-SNAPSHOT.zip)
  <!-- Version placeholder end -->
