### PR TITLE
fix: increase connector retry factor

### DIFF
--- a/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/WebSocketExchangeConnector.java
+++ b/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/WebSocketExchangeConnector.java
@@ -109,7 +109,7 @@ public class WebSocketExchangeConnector extends EmbeddedExchangeConnector {
                     1,
                     300,
                     TimeUnit.SECONDS,
-                    0.5,
+                    1.5,
                     throwable -> throwable instanceof WebSocketConnectorException connectorException && connectorException.isRetryable()
                 )
             )


### PR DESCRIPTION

**Description**

To avoid having the delay going down, the factor must be higher than 1
  
**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.1-increase-retry-factor-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/exchange/gravitee-exchange/1.2.1-increase-retry-factor-SNAPSHOT/gravitee-exchange-1.2.1-increase-retry-factor-SNAPSHOT.zip)
  <!-- Version placeholder end -->
