### PR TITLE
Add target id on adapters

### DIFF
--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/command/CommandAdapter.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/command/CommandAdapter.java
@@ -31,16 +31,19 @@ public interface CommandAdapter<C1 extends Command<?>, C2 extends Command<?>, R 
 
     /**
      * Method invoked before sending the command.
-
+     *
+     * @param targetId the target id of this command. Could be <code>null</code> during hello handshake.
+     * @param command the original {@link Command} to adapt
      * @return the command adapted
      */
-    default Single<C2> adapt(C1 command) {
+    default Single<C2> adapt(final String targetId, final C1 command) {
         return (Single<C2>) Single.just(command);
     }
 
     /**
      * Method invoke when an error is raised when sending a command.
      *
+     * @param command the original {@link Command} to adapt
      * @param throwable a throwable
      */
     default Single<R> onError(final Command<?> command, final Throwable throwable) {

--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/command/ReplyAdapter.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/command/ReplyAdapter.java
@@ -31,9 +31,12 @@ public interface ReplyAdapter<R1 extends Reply<?>, R2 extends Reply<?>> {
 
     /**
      * Method invoked when receiving the reply
+     *
+     * @param targetId the target id of this command. Could be <code>null</code> during hello handshake.
+     * @param reply the original {@link Reply} to adapt
      * @return the reply adapted
      */
-    default Single<R2> adapt(R1 reply) {
+    default Single<R2> adapt(final String targetId, final R1 reply) {
         return (Single<R2>) Single.just(reply);
     }
 }

--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/channel/AbstractWebSocketChannel.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/channel/AbstractWebSocketChannel.java
@@ -173,7 +173,7 @@ public abstract class AbstractWebSocketChannel implements Channel {
         CommandAdapter<Command<?>, Command<?>, Reply<?>> commandAdapter =
             (CommandAdapter<Command<?>, Command<?>, Reply<?>>) commandAdapters.get(command.getType());
         if (commandAdapter != null) {
-            commandObs = commandAdapter.adapt(command);
+            commandObs = commandAdapter.adapt(targetId, command);
         } else {
             commandObs = Single.just(command);
         }
@@ -213,7 +213,7 @@ public abstract class AbstractWebSocketChannel implements Channel {
             Single<? extends Reply<?>> replyObs;
             ReplyAdapter<Reply<?>, Reply<?>> replyAdapter = (ReplyAdapter<Reply<?>, Reply<?>>) replyAdapters.get(reply.getType());
             if (replyAdapter != null) {
-                replyObs = replyAdapter.adapt(reply);
+                replyObs = replyAdapter.adapt(targetId, reply);
             } else {
                 replyObs = Single.just(reply);
             }
@@ -374,7 +374,7 @@ public abstract class AbstractWebSocketChannel implements Channel {
                 }
                 CommandAdapter<C, Command<?>, R> commandAdapter = (CommandAdapter<C, Command<?>, R>) commandAdapters.get(command.getType());
                 if (commandAdapter != null) {
-                    return commandAdapter.adapt(command);
+                    return commandAdapter.adapt(targetId, command);
                 } else {
                     return Single.just(command);
                 }
@@ -421,7 +421,7 @@ public abstract class AbstractWebSocketChannel implements Channel {
             .defer(() -> {
                 ReplyAdapter<R, Reply<?>> replyAdapter = (ReplyAdapter<R, Reply<?>>) replyAdapters.get(reply.getType());
                 if (replyAdapter != null) {
-                    return replyAdapter.adapt(reply);
+                    return replyAdapter.adapt(targetId, reply);
                 } else {
                     return Single.just(reply);
                 }

--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/protocol/legacy/goodbye/GoodyeCommandAdapter.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/protocol/legacy/goodbye/GoodyeCommandAdapter.java
@@ -33,7 +33,7 @@ public class GoodyeCommandAdapter
     }
 
     @Override
-    public Single<GoodByeCommand> adapt(final io.gravitee.exchange.api.command.goodbye.GoodByeCommand command) {
+    public Single<GoodByeCommand> adapt(final String targetId, final io.gravitee.exchange.api.command.goodbye.GoodByeCommand command) {
         return Single.fromCallable(() -> {
             // The legacy protocol doesn't support reconnect option, we ignore the command to generate a websocket.close()
             // from the controller instead of doing it on controller.

--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/protocol/legacy/goodbye/LegacyGoodByeReplyAdapter.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/protocol/legacy/goodbye/LegacyGoodByeReplyAdapter.java
@@ -34,7 +34,7 @@ public class LegacyGoodByeReplyAdapter implements ReplyAdapter<GoodByeReply, io.
     }
 
     @Override
-    public Single<io.gravitee.exchange.api.command.goodbye.GoodByeReply> adapt(final GoodByeReply reply) {
+    public Single<io.gravitee.exchange.api.command.goodbye.GoodByeReply> adapt(final String targetId, final GoodByeReply reply) {
         return Single.fromCallable(() -> {
             if (reply.getCommandStatus() == CommandStatus.SUCCEEDED) {
                 return new io.gravitee.exchange.api.command.goodbye.GoodByeReply(

--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/protocol/legacy/healthcheck/HealthCheckCommandAdapter.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/protocol/legacy/healthcheck/HealthCheckCommandAdapter.java
@@ -35,7 +35,7 @@ public class HealthCheckCommandAdapter implements CommandAdapter<HealthCheckComm
     }
 
     @Override
-    public Single<HealthCheckCommand> adapt(final HealthCheckCommand command) {
+    public Single<HealthCheckCommand> adapt(final String targetId, final HealthCheckCommand command) {
         return Single.fromCallable(() -> {
             command.setReplyTimeoutMs(0);
             return command;

--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/protocol/legacy/hello/HelloCommandAdapter.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/protocol/legacy/hello/HelloCommandAdapter.java
@@ -31,7 +31,7 @@ public class HelloCommandAdapter implements CommandAdapter<io.gravitee.exchange.
     }
 
     @Override
-    public Single<HelloCommand> adapt(final io.gravitee.exchange.api.command.hello.HelloCommand command) {
+    public Single<HelloCommand> adapt(final String targetId, final io.gravitee.exchange.api.command.hello.HelloCommand command) {
         return Single.just(
             new HelloCommand(new HelloCommandPayload(new HelloCommandPayload.LegacyNode(command.getPayload().getTargetId())))
         );

--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/protocol/legacy/hello/HelloReplyAdapter.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/protocol/legacy/hello/HelloReplyAdapter.java
@@ -32,7 +32,7 @@ public class HelloReplyAdapter implements ReplyAdapter<io.gravitee.exchange.api.
     }
 
     @Override
-    public Single<HelloReply> adapt(final io.gravitee.exchange.api.command.hello.HelloReply helloReply) {
+    public Single<HelloReply> adapt(final String targetId, final io.gravitee.exchange.api.command.hello.HelloReply helloReply) {
         return Single.fromCallable(() -> {
             if (helloReply.getCommandStatus() == CommandStatus.SUCCEEDED) {
                 return new HelloReply(helloReply.getCommandId(), new HelloReplyPayload(helloReply.getPayload().getTargetId()));

--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/protocol/legacy/hello/LegacyHelloReplyAdapter.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/protocol/legacy/hello/LegacyHelloReplyAdapter.java
@@ -31,7 +31,7 @@ public class LegacyHelloReplyAdapter implements ReplyAdapter<HelloReply, io.grav
     }
 
     @Override
-    public Single<io.gravitee.exchange.api.command.hello.HelloReply> adapt(final HelloReply helloReply) {
+    public Single<io.gravitee.exchange.api.command.hello.HelloReply> adapt(final String targetId, final HelloReply helloReply) {
         return Single.just(
             new io.gravitee.exchange.api.command.hello.HelloReply(
                 helloReply.getCommandId(),

--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/protocol/legacy/ignored/NoReplyAdapter.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/protocol/legacy/ignored/NoReplyAdapter.java
@@ -31,7 +31,7 @@ public class NoReplyAdapter implements ReplyAdapter<NoReply, IgnoredReply> {
     }
 
     @Override
-    public Single<IgnoredReply> adapt(final NoReply noReply) {
+    public Single<IgnoredReply> adapt(final String targetId, final NoReply noReply) {
         return Single.just(new IgnoredReply(noReply.getCommandId()));
     }
 }

--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/protocol/legacy/primary/PrimaryCommandAdapter.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/protocol/legacy/primary/PrimaryCommandAdapter.java
@@ -35,7 +35,7 @@ public class PrimaryCommandAdapter implements CommandAdapter<PrimaryCommand, Pri
     }
 
     @Override
-    public Single<PrimaryCommand> adapt(final PrimaryCommand command) {
+    public Single<PrimaryCommand> adapt(final String targetId, final PrimaryCommand command) {
         return Single.fromCallable(() -> {
             command.setReplyTimeoutMs(0);
             return command;

--- a/gravitee-exchange-api/src/test/java/io/gravitee/exchange/api/websocket/channel/test/DummyCommandAdapter.java
+++ b/gravitee-exchange-api/src/test/java/io/gravitee/exchange/api/websocket/channel/test/DummyCommandAdapter.java
@@ -31,7 +31,7 @@ public class DummyCommandAdapter implements CommandAdapter<DummyCommand, Adapted
     }
 
     @Override
-    public Single<AdaptedDummyCommand> adapt(final DummyCommand command) {
+    public Single<AdaptedDummyCommand> adapt(final String targetId, final DummyCommand command) {
         checkpoint.flag();
         return Single.just(new AdaptedDummyCommand(command.getId(), command.getPayload()));
     }

--- a/gravitee-exchange-api/src/test/java/io/gravitee/exchange/api/websocket/channel/test/DummyReplyAdapter.java
+++ b/gravitee-exchange-api/src/test/java/io/gravitee/exchange/api/websocket/channel/test/DummyReplyAdapter.java
@@ -31,7 +31,7 @@ public class DummyReplyAdapter implements ReplyAdapter<AdaptedDummyReply, DummyR
     }
 
     @Override
-    public Single<DummyReply> adapt(final AdaptedDummyReply reply) {
+    public Single<DummyReply> adapt(final String targetId, final AdaptedDummyReply reply) {
         checkpoint.flag();
         return Single.just(new DummyReply(reply.getCommandId(), reply.getPayload()));
     }

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/channel/primary/PrimaryChannelManager.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/channel/primary/PrimaryChannelManager.java
@@ -71,20 +71,28 @@ public class PrimaryChannelManager extends AbstractService<PrimaryChannelManager
         subscriptionListenerId =
             primaryChannelEventTopic.addMessageListener(message -> {
                 ChannelEvent channelEvent = message.content();
-                log.debug(
-                    "[{}] New PrimaryChannelEvent received for channel '{}' on target '{}'",
-                    this.identifyConfiguration.id(),
-                    channelEvent.channelId(),
-                    channelEvent.targetId()
-                );
-                if (clusterManager.self().primary()) {
+                if (channelEvent.targetId() == null) {
+                    log.warn(
+                        "[{}] New PrimaryChannelEvent received for channel '{}' without any target",
+                        this.identifyConfiguration.id(),
+                        channelEvent.channelId()
+                    );
+                } else {
                     log.debug(
-                        "[{}] Handling PrimaryChannelEvent for channel '{}' on target '{}'",
+                        "[{}] New PrimaryChannelEvent received for channel '{}' on target '{}'",
                         this.identifyConfiguration.id(),
                         channelEvent.channelId(),
                         channelEvent.targetId()
                     );
-                    handleChannelEvent(channelEvent);
+                    if (clusterManager.self().primary()) {
+                        log.debug(
+                            "[{}] Handling PrimaryChannelEvent for channel '{}' on target '{}'",
+                            this.identifyConfiguration.id(),
+                            channelEvent.channelId(),
+                            channelEvent.targetId()
+                        );
+                        handleChannelEvent(channelEvent);
+                    }
                 }
             });
     }

--- a/gravitee-exchange-controller/gravitee-exchange-controller-embedded/src/main/java/io/gravitee/exchange/controller/embedded/channel/EmbeddedChannel.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-embedded/src/main/java/io/gravitee/exchange/controller/embedded/channel/EmbeddedChannel.java
@@ -106,7 +106,7 @@ public class EmbeddedChannel implements ControllerChannel, ConnectorChannel {
                         command.getType()
                     );
                     if (commandAdapter != null) {
-                        return commandAdapter.adapt(command);
+                        return commandAdapter.adapt(targetId, command);
                     } else {
                         return Single.just(command);
                     }
@@ -136,7 +136,7 @@ public class EmbeddedChannel implements ControllerChannel, ConnectorChannel {
                 .flatMap(reply -> {
                     ReplyAdapter<Reply<?>, R> replyAdapter = (ReplyAdapter<Reply<?>, R>) replyAdapters.get(reply.getType());
                     if (replyAdapter != null) {
-                        return replyAdapter.adapt(reply);
+                        return replyAdapter.adapt(targetId, reply);
                     } else {
                         return Single.just((R) reply);
                     }

--- a/gravitee-exchange-controller/gravitee-exchange-controller-embedded/src/test/java/io/gravitee/exchange/controller/embedded/channel/EmbeddedChannelTest.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-embedded/src/test/java/io/gravitee/exchange/controller/embedded/channel/EmbeddedChannelTest.java
@@ -160,7 +160,7 @@ class EmbeddedChannelTest {
                             }
 
                             @Override
-                            public Single<Command<?>> adapt(final Command<?> command) {
+                            public Single<Command<?>> adapt(final String targetId, final Command<?> command) {
                                 checkpoint.flag();
                                 return Single.just(command);
                             }
@@ -176,7 +176,7 @@ class EmbeddedChannelTest {
                             }
 
                             @Override
-                            public Single<Reply<?>> adapt(final Reply<?> reply) {
+                            public Single<Reply<?>> adapt(final String targetId, final Reply<?> reply) {
                                 checkpoint.flag();
                                 return Single.just(reply);
                             }


### PR DESCRIPTION
**Description**

In some case legacy installation wasn't providing any target id as it was hold by the handler itself. Adding the target id param will help adapting some commands.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.3-add-target-id-on-adapters-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/exchange/gravitee-exchange/1.2.3-add-target-id-on-adapters-SNAPSHOT/gravitee-exchange-1.2.3-add-target-id-on-adapters-SNAPSHOT.zip)
  <!-- Version placeholder end -->
