### PR TITLE
fix: handle internal error when handling command

### DIFF
--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/channel/AbstractWebSocketChannel.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/channel/AbstractWebSocketChannel.java
@@ -19,6 +19,7 @@ import static io.gravitee.exchange.api.command.CommandStatus.ERROR;
 
 import io.gravitee.exchange.api.channel.Channel;
 import io.gravitee.exchange.api.channel.exception.ChannelClosedException;
+import io.gravitee.exchange.api.channel.exception.ChannelException;
 import io.gravitee.exchange.api.channel.exception.ChannelInactiveException;
 import io.gravitee.exchange.api.channel.exception.ChannelInitializationException;
 import io.gravitee.exchange.api.channel.exception.ChannelNoReplyException;
@@ -201,6 +202,10 @@ public abstract class AbstractWebSocketChannel implements Channel {
                     );
                 }
                 return Completable.complete();
+            })
+            .onErrorResumeNext(throwable -> {
+                log.warn("Unexpected internal error occurred when handling command type %s".formatted(command.getId()));
+                return writeReply(new NoReply(command.getId(), "Unexpected internal error occurred"));
             })
             .subscribe();
     }


### PR DESCRIPTION

**Description**

Small PR to track internal error and return valid reply to the sender.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.4-handle-internal-handler-error-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/exchange/gravitee-exchange/1.2.4-handle-internal-handler-error-SNAPSHOT/gravitee-exchange-1.2.4-handle-internal-handler-error-SNAPSHOT.zip)
  <!-- Version placeholder end -->
