### PR TITLE
fix: handle endpoint url containing underscore

### DIFF
--- a/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/WebSocketExchangeConnector.java
+++ b/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/WebSocketExchangeConnector.java
@@ -129,7 +129,7 @@ public class WebSocketExchangeConnector extends EmbeddedExchangeConnector {
             )
             .toSingle()
             .flatMap(webSocketEndpoint -> {
-                log.debug("Trying to connect to Exchange Controller WebSocket [{}]", webSocketEndpoint.getUri());
+                log.debug("Trying to connect to Exchange Controller WebSocket [{}]", webSocketEndpoint.getUrl());
                 HttpClient httpClient = webSocketConnectorClientFactory.createHttpClient(webSocketEndpoint);
                 WebSocketConnectOptions webSocketConnectOptions = new WebSocketConnectOptions()
                     .setURI(webSocketEndpoint.resolvePath(WebsocketControllerConstants.EXCHANGE_CONTROLLER_PATH))
@@ -144,7 +144,7 @@ public class WebSocketExchangeConnector extends EmbeddedExchangeConnector {
                         webSocketConnectorClientFactory.resetEndpointRetries();
                         log.info(
                             "Connector is now connected to Exchange Controller through websocket via [{}]",
-                            webSocketEndpoint.getUri().toString()
+                            webSocketEndpoint.getUrl().toString()
                         );
                     })
                     .onErrorResumeNext(throwable -> {

--- a/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/client/WebSocketClientConfiguration.java
+++ b/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/client/WebSocketClientConfiguration.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -150,7 +151,9 @@ public class WebSocketClientConfiguration {
         List<WebSocketEndpoint> endpointsConfiguration = new ArrayList<>();
         List<String> propertyList = identifyConfiguration.getPropertyList(ENDPOINTS_KEY);
         if (propertyList != null) {
-            endpointsConfiguration.addAll(propertyList.stream().map(WebSocketEndpoint::new).toList());
+            endpointsConfiguration.addAll(
+                propertyList.stream().map(WebSocketEndpoint::newEndpoint).filter(Optional::isPresent).map(Optional::get).toList()
+            );
         }
         return endpointsConfiguration;
     }

--- a/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/client/WebSocketEndpoint.java
+++ b/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/client/WebSocketEndpoint.java
@@ -15,14 +15,19 @@
  */
 package io.gravitee.exchange.connector.websocket.client;
 
+import java.net.MalformedURLException;
 import java.net.URI;
-import lombok.Builder;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Optional;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Slf4j
 @Getter
 public class WebSocketEndpoint {
 
@@ -30,16 +35,35 @@ public class WebSocketEndpoint {
     private static final int DEFAULT_HTTP_PORT = 80;
     private static final int DEFAULT_HTTPS_PORT = 443;
 
+    private final URL url;
     private final URI uri;
 
-    @Builder
-    public WebSocketEndpoint(final String url) {
-        this.uri = URI.create(url);
+    private WebSocketEndpoint(final URL url, final URI uri) {
+        this.url = url;
+        this.uri = uri;
+    }
+
+    /**
+     * Creates a new WebSocketEndpoint instance using the given URL.
+     *
+     * @param value the URL to be used for creating the WebSocketEndpoint
+     * @return an Optional containing the WebSocketEndpoint instance if the URL is valid, otherwise an empty Optional
+     */
+    public static Optional<WebSocketEndpoint> newEndpoint(String value) {
+        try {
+            URL url = new URL(value);
+            URI uri = url.toURI();
+
+            return Optional.of(new WebSocketEndpoint(url, uri));
+        } catch (MalformedURLException | URISyntaxException e) {
+            log.warn("Invalid websocket endpoint url {}", value, e);
+            return Optional.empty();
+        }
     }
 
     public int getPort() {
-        if (uri.getPort() != -1) {
-            return uri.getPort();
+        if (url.getPort() != -1) {
+            return url.getPort();
         } else if (HTTPS_SCHEME.equals(uri.getScheme())) {
             return DEFAULT_HTTPS_PORT;
         } else {
@@ -48,7 +72,7 @@ public class WebSocketEndpoint {
     }
 
     public String getHost() {
-        return uri.getHost();
+        return url.getHost();
     }
 
     public String resolvePath(String path) {

--- a/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/test/java/io/gravitee/exchange/connector/websocket/client/WebSocketConnectorClientFactoryTest.java
+++ b/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/test/java/io/gravitee/exchange/connector/websocket/client/WebSocketConnectorClientFactoryTest.java
@@ -120,7 +120,7 @@ class WebSocketConnectorClientFactoryTest {
                 .trustStorePassword("password");
             wireMockServer = new WireMockServer(wireMockConfiguration);
             wireMockServer.start();
-            webSocketEndpoint = WebSocketEndpoint.builder().url("http://localhost:%s".formatted(wireMockServer.port())).build();
+            webSocketEndpoint = WebSocketEndpoint.newEndpoint("http://localhost:%s".formatted(wireMockServer.port())).orElseThrow();
         }
 
         @AfterAll
@@ -159,7 +159,7 @@ class WebSocketConnectorClientFactoryTest {
                 .trustStorePassword("password");
             wireMockServer = new WireMockServer(wireMockConfiguration);
             wireMockServer.start();
-            webSocketEndpoint = WebSocketEndpoint.builder().url("https://localhost:%s".formatted(wireMockServer.httpsPort())).build();
+            webSocketEndpoint = WebSocketEndpoint.newEndpoint("https://localhost:%s".formatted(wireMockServer.httpsPort())).orElseThrow();
         }
 
         @AfterAll
@@ -235,7 +235,7 @@ class WebSocketConnectorClientFactoryTest {
                 .needClientAuth(true);
             wireMockServer = new WireMockServer(wireMockConfiguration);
             wireMockServer.start();
-            webSocketEndpoint = WebSocketEndpoint.builder().url("https://localhost:%s".formatted(wireMockServer.httpsPort())).build();
+            webSocketEndpoint = WebSocketEndpoint.newEndpoint("https://localhost:%s".formatted(wireMockServer.httpsPort())).orElseThrow();
         }
 
         @AfterAll

--- a/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/test/java/io/gravitee/exchange/connector/websocket/client/WebSocketEndpointTest.java
+++ b/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/test/java/io/gravitee/exchange/connector/websocket/client/WebSocketEndpointTest.java
@@ -18,6 +18,7 @@ package io.gravitee.exchange.connector.websocket.client;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.stream.Stream;
+import lombok.SneakyThrows;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -34,6 +35,8 @@ class WebSocketEndpointTest {
     private static Stream<Arguments> urls() {
         return Stream.of(
             // URL / host / port / root path
+            Arguments.of("http://management_api:8072", "management_api", 8072),
+            Arguments.of("http://management-api.gravitee.io:8072", "management-api.gravitee.io", 8072),
             Arguments.of("http://localhost:8062", "localhost", 8062),
             Arguments.of("http://localhost:8062/", "localhost", 8062),
             Arguments.of("https://localhost:8063", "localhost", 8063),
@@ -45,16 +48,21 @@ class WebSocketEndpointTest {
 
     @ParameterizedTest
     @MethodSource("urls")
+    @SneakyThrows
     void should_create_default_websocket_endpoint(String baseUrl, String host, int port) {
-        WebSocketEndpoint endpoint = new WebSocketEndpoint(baseUrl);
-        assertThat(endpoint.getHost()).isEqualTo(host);
-        assertThat(endpoint.getPort()).isEqualTo(port);
+        var endpoint = WebSocketEndpoint.newEndpoint(baseUrl);
+        assertThat(endpoint)
+            .isPresent()
+            .get()
+            .extracting(WebSocketEndpoint::getHost, WebSocketEndpoint::getPort)
+            .containsExactly(host, port);
     }
 
     @ParameterizedTest
     @MethodSource("urls")
+    @SneakyThrows
     void should_resolve_path(String baseUrl) {
-        WebSocketEndpoint endpoint = new WebSocketEndpoint(baseUrl);
+        WebSocketEndpoint endpoint = WebSocketEndpoint.newEndpoint(baseUrl).orElseThrow();
         assertThat(endpoint.resolvePath("/path")).isEqualTo("/path");
     }
 }


### PR DESCRIPTION
**Description**

Handle endpoint url containing underscore

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.5-fix-websocket-endpoint-creation-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/exchange/gravitee-exchange/1.2.5-fix-websocket-endpoint-creation-SNAPSHOT/gravitee-exchange-1.2.5-fix-websocket-endpoint-creation-SNAPSHOT.zip)
  <!-- Version placeholder end -->
