### PR TITLE
feat(connector): handle URL containing a path

### DIFF
--- a/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/client/WebSocketConnectorClientFactory.java
+++ b/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/client/WebSocketConnectorClientFactory.java
@@ -22,7 +22,7 @@ import io.vertx.core.net.PemTrustOptions;
 import io.vertx.core.net.PfxOptions;
 import io.vertx.rxjava3.core.Vertx;
 import io.vertx.rxjava3.core.http.HttpClient;
-import java.net.URI;
+import java.net.URL;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Getter;
@@ -65,12 +65,12 @@ public class WebSocketConnectorClientFactory {
     }
 
     public HttpClient createHttpClient(WebSocketEndpoint websocketEndpoint) {
-        URI target = websocketEndpoint.getUri();
+        URL target = websocketEndpoint.getUrl();
         HttpClientOptions options = new HttpClientOptions();
         options.setDefaultHost(websocketEndpoint.getHost());
         options.setDefaultPort(websocketEndpoint.getPort());
 
-        if (isSecureProtocol(target.getScheme())) {
+        if (isSecureProtocol(target.getProtocol())) {
             options.setSsl(true);
             options.setTrustAll(configuration.trustAll());
             options.setVerifyHost(configuration.verifyHost());


### PR DESCRIPTION
**Description**

When deploying a Controller in Kubernetes behind an Ingress, the URL to configure in the Connector's side may contain a path (so the Ingress can redirect to the proper service)


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.3.0-accept-path-prefix-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/exchange/gravitee-exchange/1.3.0-accept-path-prefix-SNAPSHOT/gravitee-exchange-1.3.0-accept-path-prefix-SNAPSHOT.zip)
  <!-- Version placeholder end -->
