### PR TITLE
feat(controller): register listener to listen primary channel eviction

### DIFF
--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/controller/ExchangeController.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/controller/ExchangeController.java
@@ -21,6 +21,7 @@ import io.gravitee.exchange.api.batch.BatchObserver;
 import io.gravitee.exchange.api.batch.KeyBatchObserver;
 import io.gravitee.exchange.api.command.Command;
 import io.gravitee.exchange.api.command.Reply;
+import io.gravitee.exchange.api.controller.listeners.TargetListener;
 import io.gravitee.exchange.api.controller.metrics.ChannelMetric;
 import io.gravitee.exchange.api.controller.metrics.TargetMetric;
 import io.reactivex.rxjava3.core.Completable;
@@ -32,6 +33,18 @@ import io.reactivex.rxjava3.core.Single;
  * @author GraviteeSource Team
  */
 public interface ExchangeController extends Service<ExchangeController> {
+    /**
+     * Add a {@link TargetListener} that will be notified
+     * @param targetListener {@link TargetListener} that will be notified
+     */
+    ExchangeController addListener(TargetListener targetListener);
+
+    /**
+     * Remove a {@link TargetListener}
+     * @param targetListener {@link TargetListener} to remove.
+     */
+    ExchangeController removeListener(TargetListener targetListener);
+
     /**
      * Return all target metrics
      *

--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/controller/listeners/TargetListener.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/controller/listeners/TargetListener.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.exchange.api.controller.listeners;
+
+public interface TargetListener {
+    /**
+     * Called when the primary channel is evicted for a specific target.
+     *
+     * @param targetId the ID of the target for which the primary channel is evicted
+     */
+    default void onPrimaryChannelEvicted(String targetId) {}
+}

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/channel/primary/PrimaryChannelEvictedEvent.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/channel/primary/PrimaryChannelEvictedEvent.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.exchange.controller.core.channel.primary;
+
+import java.io.Serializable;
+import lombok.Builder;
+
+@Builder
+public record PrimaryChannelEvictedEvent(String targetId) implements Serializable {}


### PR DESCRIPTION
**Description**

Controller exposes methods to (un)register listeners. Those listeners should implement TargetListener interface.

A new event for primary channel evictions is added. The event is listened for in DefaultExchangeController, and when triggered, invokes the 'onPrimaryChannelEvicted' method on all relevant TargetListeners.

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.4.0-support-listener-primary-evicted-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/exchange/gravitee-exchange/1.4.0-support-listener-primary-evicted-SNAPSHOT/gravitee-exchange-1.4.0-support-listener-primary-evicted-SNAPSHOT.zip)
  <!-- Version placeholder end -->
