### PR TITLE
fix: add throwable to internal error warn log

### DIFF
--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/channel/AbstractWebSocketChannel.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/channel/AbstractWebSocketChannel.java
@@ -19,7 +19,6 @@ import static io.gravitee.exchange.api.command.CommandStatus.ERROR;
 
 import io.gravitee.exchange.api.channel.Channel;
 import io.gravitee.exchange.api.channel.exception.ChannelClosedException;
-import io.gravitee.exchange.api.channel.exception.ChannelException;
 import io.gravitee.exchange.api.channel.exception.ChannelInactiveException;
 import io.gravitee.exchange.api.channel.exception.ChannelInitializationException;
 import io.gravitee.exchange.api.channel.exception.ChannelNoReplyException;
@@ -204,7 +203,7 @@ public abstract class AbstractWebSocketChannel implements Channel {
                 return Completable.complete();
             })
             .onErrorResumeNext(throwable -> {
-                log.warn("Unexpected internal error occurred when handling command type %s".formatted(command.getId()));
+                log.warn("Unexpected internal error occurred when handling command type %s".formatted(command.getType()), throwable);
                 return writeReply(new NoReply(command.getId(), "Unexpected internal error occurred"));
             })
             .subscribe();


### PR DESCRIPTION

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.4.2-add-missing-throwable-on-warn-log-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/exchange/gravitee-exchange/1.4.2-add-missing-throwable-on-warn-log-SNAPSHOT/gravitee-exchange-1.4.2-add-missing-throwable-on-warn-log-SNAPSHOT.zip)
  <!-- Version placeholder end -->
