### PR TITLE
fix: avoid warn log when the timeout is inevitable

### DIFF
--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/channel/AbstractWebSocketChannel.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/channel/AbstractWebSocketChannel.java
@@ -393,7 +393,13 @@ public abstract class AbstractWebSocketChannel implements Channel {
                         adaptedCommand.getReplyTimeoutMs(),
                         TimeUnit.MILLISECONDS,
                         Single.error(() -> {
-                            log.warn("No reply received in time for command [{}, {}]", adaptedCommand.getType(), adaptedCommand.getId());
+                            if (adaptedCommand.getReplyTimeoutMs() > 0) {
+                                log.warn(
+                                    "No reply received in time for command [{}, {}]",
+                                    adaptedCommand.getType(),
+                                    adaptedCommand.getId()
+                                );
+                            }
                             throw new ChannelTimeoutException();
                         })
                     )


### PR DESCRIPTION
**Issue**

This is how it looks today in Cockpit `preprod`. Lot of noise for an "expected" behaviour

![Screenshot 2024-05-28 at 16 45 30](https://github.com/gravitee-io/gravitee-exchange/assets/8580702/2831ba5d-b8a0-4d73-84d2-b45e58001069)

**Description**

Only log a message when there was actually a configured timeout.
This avoids logging unnecessary message for legacy HEALTH_CHECK commands.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.5.1-fix-warn-timeout-message-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/exchange/gravitee-exchange/1.5.1-fix-warn-timeout-message-SNAPSHOT/gravitee-exchange-1.5.1-fix-warn-timeout-message-SNAPSHOT.zip)
  <!-- Version placeholder end -->
