### PR TITLE
fix: set default enum value for CommandStatus

### DIFF
--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/command/CommandStatus.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/command/CommandStatus.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.exchange.api.command;
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
@@ -38,5 +40,6 @@ public enum CommandStatus {
     /**
      * The command got an unexpected error.
      */
+    @JsonEnumDefaultValue
     ERROR,
 }

--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/command/DefaultExchangeSerDe.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/command/DefaultExchangeSerDe.java
@@ -15,8 +15,12 @@
  */
 package io.gravitee.exchange.api.websocket.command;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import io.gravitee.exchange.api.command.Command;
@@ -95,7 +99,12 @@ public class DefaultExchangeSerDe implements ExchangeSerDe {
         final Map<String, Class<? extends Command<?>>> customCommandTypes,
         final Map<String, Class<? extends Reply<?>>> customReplyTypes
     ) {
-        this.objectMapper = objectMapper;
+        this.objectMapper =
+            objectMapper
+                .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+                .disable(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES)
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
         registerCommandTypes(objectMapper, customCommandTypes);
         registerReplyTypes(objectMapper, customReplyTypes);

--- a/gravitee-exchange-api/src/test/java/io/gravitee/exchange/api/websocket/command/DefaultExchangeSerDeTest.java
+++ b/gravitee-exchange-api/src/test/java/io/gravitee/exchange/api/websocket/command/DefaultExchangeSerDeTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.exchange.api.command.Command;
+import io.gravitee.exchange.api.command.CommandStatus;
 import io.gravitee.exchange.api.command.Reply;
 import io.gravitee.exchange.api.command.goodbye.GoodByeCommand;
 import io.gravitee.exchange.api.command.goodbye.GoodByeCommandPayload;
@@ -144,6 +145,17 @@ class DefaultExchangeSerDeTest {
             assertThat(reply).isInstanceOf(UnknownReply.class);
         }
 
+        @Test
+        void should_deserialize_reply_with_unknown_status() {
+            Reply<?> reply = cut.deserializeAsReply(
+                ProtocolVersion.V1,
+                "wrong",
+                "{\"commandId\":\"commandId\",\"type\":\"HELLO\",\"commandStatus\":\"FAILURE\",\"errorDetails\":\"error\"}"
+            );
+            assertThat(reply).isInstanceOf(HelloReply.class);
+            assertThat(reply.getCommandStatus()).isEqualTo(CommandStatus.ERROR);
+        }
+
         private static Stream<Arguments> knownReplies() {
             return Stream.of(
                 Arguments.of(
@@ -158,7 +170,7 @@ class DefaultExchangeSerDeTest {
                 ),
                 Arguments.of(
                     HealthCheckCommand.COMMAND_TYPE,
-                    "{\"commandId\":\"commandId\",\"type\":\"HEALTH_CHECK\",\"commandStatus\":\"SUCCEEDED\",\"payload\":{\"healthy\":true,\"detail\":null}}",
+                    "{\"commandId\":\"commandId\",\"type\":\"HEALTH_CHECK\",\"commandStatus\":\"SUCCEEDED\",\"payload\":{\"healthy\":true}}",
                     new HealthCheckReply("commandId", new HealthCheckReplyPayload(true, null))
                 ),
                 Arguments.of(


### PR DESCRIPTION
**Issue**

[Link to the original issue](https://gravitee.atlassian.net/browse/CJ-1802)

**Description**

Add default value for unknow command status in order to support old FAILURE value.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.5.2-CJ-1802-Fallback-to-default-status-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/exchange/gravitee-exchange/1.5.2-CJ-1802-Fallback-to-default-status-SNAPSHOT/gravitee-exchange-1.5.2-CJ-1802-Fallback-to-default-status-SNAPSHOT.zip)
  <!-- Version placeholder end -->
