### PR TITLE
Add rescalling mechanism

### DIFF
--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/channel/Channel.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/channel/Channel.java
@@ -70,6 +70,13 @@ public interface Channel {
     boolean isActive();
 
     /**
+     * Return <code>true</code> is the current channel has pending commands waiting for reply, <code>false</code> otherwise.
+     *
+     * @return status of the channel.
+     */
+    boolean hasPendingCommands();
+
+    /**
      * Send the actual commands to the current channel. In case of error, different exception could be returned:
      * <ul>
      * <li>if the channel is inactive {@link ChannelInitializationException} is signaled</li>

--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/channel/Channel.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/channel/Channel.java
@@ -70,7 +70,7 @@ public interface Channel {
     boolean isActive();
 
     /**
-     * Return <code>true</code> is the current channel has pending commands waiting for reply, <code>false</code> otherwise.
+     * Return <code>true</code> if the current channel has pending commands waiting for reply, <code>false</code> otherwise.
      *
      * @return status of the channel.
      */

--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/controller/metrics/ChannelMetric.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/controller/metrics/ChannelMetric.java
@@ -31,5 +31,7 @@ import lombok.experimental.Accessors;
 public class ChannelMetric {
 
     String id;
+    boolean active;
+    boolean pendingCommands;
     boolean primary;
 }

--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/channel/AbstractWebSocketChannel.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/channel/AbstractWebSocketChannel.java
@@ -115,6 +115,11 @@ public abstract class AbstractWebSocketChannel implements Channel {
     }
 
     @Override
+    public boolean hasPendingCommands() {
+        return !resultEmitters.isEmpty();
+    }
+
+    @Override
     public Completable initialize() {
         return Completable
             .create(emitter -> {

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/pom.xml
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/pom.xml
@@ -67,5 +67,18 @@
             <version>${gravitee-node.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-cache-plugin-standalone</artifactId>
+            <version>${gravitee-node.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-cluster-plugin-standalone</artifactId>
+            <version>${gravitee-node.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 </project>

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/channel/ChannelManager.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/channel/ChannelManager.java
@@ -236,7 +236,19 @@ public class ChannelManager extends AbstractService<ChannelManager> {
                     .flattenStreamAsFlowable(primaryChannel ->
                         channelIds
                             .stream()
-                            .map(channelId -> ChannelMetric.builder().id(channelId).primary(channelId.equals(primaryChannel)).build())
+                            .map(channelId -> {
+                                ChannelMetric.ChannelMetricBuilder metricBuilder = ChannelMetric
+                                    .builder()
+                                    .id(channelId)
+                                    .primary(channelId.equals(primaryChannel));
+                                this.localChannelRegistry.getById(channelId)
+                                    .ifPresent(controllerChannel ->
+                                        metricBuilder
+                                            .active(controllerChannel.isActive())
+                                            .pendingCommands(controllerChannel.hasPendingCommands())
+                                    );
+                                return metricBuilder.build();
+                            })
                     )
                     .toList()
                     .map(channelMetrics -> TargetMetric.builder().id(targetId).channelMetrics(channelMetrics).build());

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/channel/ChannelManagerTest.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/channel/ChannelManagerTest.java
@@ -1,0 +1,327 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.exchange.controller.core.channel;
+
+import static io.gravitee.exchange.controller.core.channel.primary.PrimaryChannelManager.PRIMARY_CHANNEL_EVENTS_TOPIC;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.exchange.api.command.Command;
+import io.gravitee.exchange.api.command.CommandHandler;
+import io.gravitee.exchange.api.command.Reply;
+import io.gravitee.exchange.api.command.healtcheck.HealthCheckCommand;
+import io.gravitee.exchange.api.command.healtcheck.HealthCheckReply;
+import io.gravitee.exchange.api.command.healtcheck.HealthCheckReplyPayload;
+import io.gravitee.exchange.api.command.hello.HelloCommand;
+import io.gravitee.exchange.api.command.hello.HelloCommandPayload;
+import io.gravitee.exchange.api.command.hello.HelloReply;
+import io.gravitee.exchange.api.command.hello.HelloReplyPayload;
+import io.gravitee.exchange.api.command.primary.PrimaryCommand;
+import io.gravitee.exchange.api.command.primary.PrimaryReply;
+import io.gravitee.exchange.api.command.primary.PrimaryReplyPayload;
+import io.gravitee.exchange.api.configuration.IdentifyConfiguration;
+import io.gravitee.exchange.api.controller.metrics.ChannelMetric;
+import io.gravitee.exchange.api.controller.metrics.TargetMetric;
+import io.gravitee.exchange.controller.core.channel.exception.NoChannelFoundException;
+import io.gravitee.exchange.controller.core.channel.primary.ChannelEvent;
+import io.gravitee.node.api.cache.CacheManager;
+import io.gravitee.node.api.cluster.ClusterManager;
+import io.gravitee.node.api.cluster.messaging.Topic;
+import io.gravitee.node.plugin.cache.standalone.StandaloneCacheManager;
+import io.gravitee.node.plugin.cluster.standalone.StandaloneClusterManager;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+import io.reactivex.rxjava3.schedulers.TestScheduler;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(VertxExtension.class)
+class ChannelManagerTest {
+
+    private CacheManager cacheManager;
+    private ClusterManager clusterManager;
+    private MockEnvironment environment;
+    private IdentifyConfiguration identifyConfiguration;
+    private ChannelManager cut;
+    private Topic<ChannelEvent> primaryChannelEventTopic;
+
+    @BeforeEach
+    public void beforeEach(Vertx vertx) throws Exception {
+        environment = new MockEnvironment();
+        identifyConfiguration = new IdentifyConfiguration(environment);
+        cacheManager = new StandaloneCacheManager();
+        cacheManager.start();
+        clusterManager = new StandaloneClusterManager(vertx);
+        clusterManager.start();
+        cut = new ChannelManager(identifyConfiguration, clusterManager, cacheManager);
+        cut.start();
+        primaryChannelEventTopic = clusterManager.topic(identifyConfiguration.identifyName(PRIMARY_CHANNEL_EVENTS_TOPIC));
+    }
+
+    @Test
+    void should_register_new_channel(VertxTestContext vertxTestContext) throws InterruptedException {
+        SampleChannel sampleChannel = new SampleChannel("channelId", "targetId");
+        Checkpoint checkpoint = vertxTestContext.checkpoint();
+        primaryChannelEventTopic.addMessageListener(message -> {
+            if (message.content().alive()) {
+                checkpoint.flag();
+            }
+        });
+        cut.register(sampleChannel).test().awaitDone(10, TimeUnit.SECONDS);
+        assertThat(vertxTestContext.awaitCompletion(10, TimeUnit.SECONDS)).isTrue();
+
+        assertThat(cut.getChannelById("channelId")).isNotNull();
+    }
+
+    @Test
+    void should_receive_primary_command_after_register_new_primary_channel(VertxTestContext vertxTestContext) throws InterruptedException {
+        Checkpoint checkpoint = vertxTestContext.checkpoint();
+        SampleChannel sampleChannel = new SampleChannel("channelId", "targetId");
+        sampleChannel.addCommandHandlers(
+            List.of(
+                new CommandHandler<>() {
+                    @Override
+                    public Single<Reply<?>> handle(final Command<?> command) {
+                        return Single.fromCallable(() -> {
+                            checkpoint.flag();
+                            return new PrimaryReply(command.getId(), new PrimaryReplyPayload());
+                        });
+                    }
+
+                    @Override
+                    public String supportType() {
+                        return PrimaryCommand.COMMAND_TYPE;
+                    }
+                }
+            )
+        );
+        cut.register(sampleChannel).test().awaitDone(10, TimeUnit.SECONDS);
+        assertThat(vertxTestContext.awaitCompletion(10, TimeUnit.SECONDS)).isTrue();
+
+        assertThat(cut.getChannelById("channelId")).isNotNull();
+    }
+
+    @Test
+    void should_receive_healthCheck_command(VertxTestContext vertxTestContext) {
+        try {
+            TestScheduler testScheduler = new TestScheduler();
+            RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
+            // Restart cut to apply test scheduler
+            cut.stop();
+            cut.start();
+
+            Checkpoint checkpoint = vertxTestContext.checkpoint();
+            SampleChannel sampleChannel = new SampleChannel("channelId", "targetId");
+            sampleChannel.addCommandHandlers(
+                List.of(
+                    new CommandHandler<>() {
+                        @Override
+                        public Single<Reply<?>> handle(final Command<?> command) {
+                            return Single.fromCallable(() -> {
+                                checkpoint.flag();
+                                return new HealthCheckReply(command.getId(), new HealthCheckReplyPayload(true, null));
+                            });
+                        }
+
+                        @Override
+                        public String supportType() {
+                            return HealthCheckCommand.COMMAND_TYPE;
+                        }
+                    }
+                )
+            );
+            cut.register(sampleChannel).test().awaitDone(10, TimeUnit.SECONDS);
+            testScheduler.advanceTimeBy(30, TimeUnit.SECONDS);
+            assertThat(vertxTestContext.awaitCompletion(10, TimeUnit.SECONDS)).isTrue();
+            assertThat(cut.getChannelById("channelId")).isNotNull();
+        } catch (Exception e) {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    void should_not_register_new_channel_if_initialization_failed() {
+        SampleChannel sampleChannel = new SampleChannel("channelId", "targetId");
+        sampleChannel.setInitialize(Completable.error(new RuntimeException()));
+        cut.register(sampleChannel).test().awaitDone(10, TimeUnit.SECONDS);
+
+        assertThat(cut.getChannelById("channelId")).isNull();
+    }
+
+    @Test
+    void should_unregister_channel(VertxTestContext vertxTestContext) throws InterruptedException {
+        SampleChannel sampleChannel = new SampleChannel("channelId", "targetId");
+        Checkpoint checkpoint = vertxTestContext.checkpoint();
+        primaryChannelEventTopic.addMessageListener(message -> {
+            if (!message.content().alive()) {
+                checkpoint.flag();
+            }
+        });
+        cut
+            .register(sampleChannel)
+            .andThen(
+                Completable.fromRunnable(() -> {
+                    assertThat(cut.getChannelById("channelId")).isNotNull();
+                })
+            )
+            .andThen(cut.unregister(sampleChannel))
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS);
+        assertThat(vertxTestContext.awaitCompletion(10, TimeUnit.SECONDS)).isTrue();
+
+        assertThat(cut.getChannelById("channelId")).isNull();
+    }
+
+    @Test
+    void should_unregister_channel_even_if_close_failed() {
+        SampleChannel sampleChannel = new SampleChannel("channelId", "targetId");
+        sampleChannel.setClose(Completable.error(new RuntimeException()));
+        cut
+            .register(sampleChannel)
+            .andThen(
+                Completable.fromRunnable(() -> {
+                    assertThat(cut.getChannelById("channelId")).isNotNull();
+                })
+            )
+            .andThen(cut.unregister(sampleChannel))
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS);
+
+        assertThat(cut.getChannelById("channelId")).isNull();
+    }
+
+    @Test
+    void should_return_metrics_for_target(VertxTestContext vertxTestContext) throws InterruptedException {
+        Checkpoint checkpoint = vertxTestContext.checkpoint(3);
+        primaryChannelEventTopic.addMessageListener(message -> checkpoint.flag());
+
+        SampleChannel sampleChannel = new SampleChannel("channelId", "targetId");
+        SampleChannel sampleChannel2 = new SampleChannel("channelId2", "targetId", false);
+        SampleChannel sampleChannel3 = new SampleChannel("channelId3", "targetId2");
+        cut
+            .register(sampleChannel)
+            .andThen(cut.register(sampleChannel2))
+            .andThen(cut.register(sampleChannel3))
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS);
+        assertThat(vertxTestContext.awaitCompletion(10, TimeUnit.SECONDS)).isTrue();
+
+        cut
+            .targetsMetric()
+            .toList()
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertValue(targetMetrics -> {
+                for (TargetMetric targetMetric : targetMetrics) {
+                    if (targetMetric.id().equals("targetId")) {
+                        assertThat(targetMetric.channelMetrics())
+                            .extracting(ChannelMetric::id, ChannelMetric::primary, ChannelMetric::active)
+                            .containsOnly(Tuple.tuple("channelId", true, true), Tuple.tuple("channelId2", false, false));
+                    } else if (targetMetric.id().equals("targetId2")) {
+                        assertThat(targetMetric.channelMetrics())
+                            .extracting(ChannelMetric::id, ChannelMetric::primary, ChannelMetric::active)
+                            .containsOnly(Tuple.tuple("channelId3", true, true));
+                    } else {
+                        return false;
+                    }
+                }
+                return true;
+            });
+    }
+
+    @Test
+    void should_return_metrics_for_channel(VertxTestContext vertxTestContext) throws InterruptedException {
+        Checkpoint checkpoint = vertxTestContext.checkpoint(3);
+        primaryChannelEventTopic.addMessageListener(message -> checkpoint.flag());
+
+        SampleChannel sampleChannel = new SampleChannel("channelId", "targetId");
+        SampleChannel sampleChannel2 = new SampleChannel("channelId2", "targetId", false);
+        SampleChannel sampleChannel3 = new SampleChannel("channelId3", "targetId2");
+        cut
+            .register(sampleChannel)
+            .andThen(cut.register(sampleChannel2))
+            .andThen(cut.register(sampleChannel3))
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS);
+        assertThat(vertxTestContext.awaitCompletion(10, TimeUnit.SECONDS)).isTrue();
+
+        cut
+            .channelsMetric("targetId")
+            .toList()
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertValue(channelMetrics -> {
+                assertThat(channelMetrics)
+                    .extracting(ChannelMetric::id, ChannelMetric::active, ChannelMetric::primary)
+                    .containsOnly(Tuple.tuple("channelId", true, true), Tuple.tuple("channelId2", false, false));
+                return true;
+            });
+    }
+
+    @Test
+    void should_send_command_to_channel(VertxTestContext vertxTestContext) throws InterruptedException {
+        Checkpoint checkpoint = vertxTestContext.checkpoint(2);
+        primaryChannelEventTopic.addMessageListener(message -> checkpoint.flag());
+
+        SampleChannel sampleChannel = new SampleChannel("channelId", "targetId");
+        sampleChannel.addCommandHandlers(
+            List.of(
+                new CommandHandler<>() {
+                    @Override
+                    public Single<Reply<?>> handle(final Command<?> command) {
+                        return Single.fromCallable(() -> {
+                            checkpoint.flag();
+                            return new HelloReply(command.getId(), new HelloReplyPayload("targetId"));
+                        });
+                    }
+
+                    @Override
+                    public String supportType() {
+                        return HelloCommand.COMMAND_TYPE;
+                    }
+                }
+            )
+        );
+        SampleChannel sampleChannel2 = new SampleChannel("channelId2", "targetId", false);
+        cut
+            .register(sampleChannel)
+            .andThen(cut.send(new HelloCommand(new HelloCommandPayload()), "targetId"))
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS);
+        assertThat(vertxTestContext.awaitCompletion(10, TimeUnit.SECONDS)).isTrue();
+    }
+
+    @Test
+    void should_return_error_when_sending_command_without_channel() {
+        cut.send(new HelloCommand(new HelloCommandPayload()), "targetId").test().assertError(NoChannelFoundException.class);
+    }
+}

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/channel/SampleChannel.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/channel/SampleChannel.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.exchange.controller.core.channel;
+
+import io.gravitee.exchange.api.channel.exception.ChannelNoReplyException;
+import io.gravitee.exchange.api.channel.exception.ChannelTimeoutException;
+import io.gravitee.exchange.api.command.Command;
+import io.gravitee.exchange.api.command.CommandAdapter;
+import io.gravitee.exchange.api.command.CommandHandler;
+import io.gravitee.exchange.api.command.Reply;
+import io.gravitee.exchange.api.command.ReplyAdapter;
+import io.gravitee.exchange.api.controller.ControllerChannel;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.CompletableSource;
+import io.reactivex.rxjava3.core.Single;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+public class SampleChannel implements ControllerChannel {
+
+    private final Map<String, CommandHandler<? extends Command<?>, ? extends Reply<?>>> commandHandlers = new ConcurrentHashMap<>();
+    private final Map<String, CommandAdapter<? extends Command<?>, ? extends Command<?>, ? extends Reply<?>>> commandAdapters =
+        new ConcurrentHashMap<>();
+    private final Map<String, ReplyAdapter<? extends Reply<?>, ? extends Reply<?>>> replyAdapters = new ConcurrentHashMap<>();
+    private final String channelId;
+    private final String targetId;
+    private boolean active;
+    private CompletableSource initializeCompletableSource = Completable.complete();
+    private CompletableSource closeCompletableSource = Completable.complete();
+
+    public SampleChannel(String channelId, String targetId) {
+        this(channelId, targetId, true);
+    }
+
+    public SampleChannel(String channelId, String targetId, boolean active) {
+        this.channelId = channelId;
+        this.targetId = targetId;
+        this.active = active;
+    }
+
+    @Override
+    public String id() {
+        return channelId;
+    }
+
+    @Override
+    public String targetId() {
+        return targetId;
+    }
+
+    @Override
+    public Completable initialize() {
+        return Completable.wrap(this.initializeCompletableSource);
+    }
+
+    public void setInitialize(final CompletableSource completableSource) {
+        this.initializeCompletableSource = completableSource;
+    }
+
+    @Override
+    public Completable close() {
+        return Completable.wrap(this.closeCompletableSource);
+    }
+
+    public void setClose(final CompletableSource completableSource) {
+        this.closeCompletableSource = completableSource;
+    }
+
+    @Override
+    public boolean isActive() {
+        return this.active;
+    }
+
+    @Override
+    public boolean hasPendingCommands() {
+        return false;
+    }
+
+    @Override
+    public <C extends Command<?>, R extends Reply<?>> Single<R> send(final C command) {
+        CommandHandler<?, ?> commandHandler = commandHandlers.get(command.getType());
+        if (commandHandler != null) {
+            return Single
+                .defer(() -> {
+                    CommandAdapter<C, Command<?>, Reply<?>> commandAdapter = (CommandAdapter<C, Command<?>, Reply<?>>) commandAdapters.get(
+                        command.getType()
+                    );
+                    if (commandAdapter != null) {
+                        return commandAdapter.adapt(targetId, command);
+                    } else {
+                        return Single.just(command);
+                    }
+                })
+                .flatMap(single -> {
+                    CommandHandler<Command<?>, Reply<?>> castHandler = (CommandHandler<Command<?>, Reply<?>>) commandHandler;
+                    return castHandler.handle(command);
+                })
+                .timeout(
+                    command.getReplyTimeoutMs(),
+                    TimeUnit.MILLISECONDS,
+                    Single.fromCallable(() -> {
+                        throw new ChannelTimeoutException();
+                    })
+                )
+                .onErrorResumeNext(throwable -> {
+                    CommandAdapter<C, Command<?>, R> commandAdapter = (CommandAdapter<C, Command<?>, R>) commandAdapters.get(
+                        command.getType()
+                    );
+                    if (commandAdapter != null) {
+                        return commandAdapter.onError(command, throwable);
+                    } else {
+                        return Single.error(throwable);
+                    }
+                })
+                .flatMap(reply -> {
+                    ReplyAdapter<Reply<?>, R> replyAdapter = (ReplyAdapter<Reply<?>, R>) replyAdapters.get(reply.getType());
+                    if (replyAdapter != null) {
+                        return replyAdapter.adapt(targetId, reply);
+                    } else {
+                        return Single.just((R) reply);
+                    }
+                });
+        } else {
+            return Single.error(() -> {
+                String message = "No handler found for command type %s".formatted(command.getType());
+                throw new ChannelNoReplyException(message);
+            });
+        }
+    }
+
+    @Override
+    public void addCommandHandlers(final List<CommandHandler<? extends Command<?>, ? extends Reply<?>>> commandHandlers) {
+        if (commandHandlers != null) {
+            commandHandlers.forEach(commandHandler -> this.commandHandlers.putIfAbsent(commandHandler.supportType(), commandHandler));
+        }
+    }
+
+    @Override
+    public void addCommandAdapters(
+        final List<CommandAdapter<? extends Command<?>, ? extends Command<?>, ? extends Reply<?>>> commandAdapters
+    ) {
+        if (commandAdapters != null) {
+            commandAdapters.forEach(commandDecorator -> this.commandAdapters.putIfAbsent(commandDecorator.supportType(), commandDecorator));
+        }
+    }
+
+    @Override
+    public void addReplyAdapters(final List<ReplyAdapter<? extends Reply<?>, ? extends Reply<?>>> replyAdapters) {
+        if (replyAdapters != null) {
+            replyAdapters.forEach(replyDecorator -> this.replyAdapters.putIfAbsent(replyDecorator.supportType(), replyDecorator));
+        }
+    }
+
+    @Override
+    public void enforceActiveStatus(final boolean isActive) {
+        this.active = isActive;
+    }
+}

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/channel/primary/PrimaryChannelCandidateStoreTest.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/channel/primary/PrimaryChannelCandidateStoreTest.java
@@ -27,12 +27,15 @@ import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class PrimaryChannelCandidateStoreTest {
 
     private Cache<String, Set<String>> store;

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/channel/primary/PrimaryChannelManagerTest.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/channel/primary/PrimaryChannelManagerTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.exchange.controller.core.channel.primary;
+
+import static io.gravitee.exchange.controller.core.channel.primary.PrimaryChannelManager.PRIMARY_CHANNEL_CACHE;
+import static io.gravitee.exchange.controller.core.channel.primary.PrimaryChannelManager.PRIMARY_CHANNEL_EVENTS_ELECTED_TOPIC;
+import static io.gravitee.exchange.controller.core.channel.primary.PrimaryChannelManager.PRIMARY_CHANNEL_EVENTS_EVICTED_TOPIC;
+import static io.gravitee.exchange.controller.core.channel.primary.PrimaryChannelManager.PRIMARY_CHANNEL_EVENTS_TOPIC;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.exchange.api.command.Command;
+import io.gravitee.exchange.api.command.CommandAdapter;
+import io.gravitee.exchange.api.command.CommandHandler;
+import io.gravitee.exchange.api.command.Reply;
+import io.gravitee.exchange.api.command.ReplyAdapter;
+import io.gravitee.exchange.api.configuration.IdentifyConfiguration;
+import io.gravitee.exchange.api.controller.ControllerChannel;
+import io.gravitee.exchange.controller.core.channel.SampleChannel;
+import io.gravitee.node.api.cache.Cache;
+import io.gravitee.node.api.cache.CacheConfiguration;
+import io.gravitee.node.api.cache.CacheManager;
+import io.gravitee.node.api.cluster.ClusterManager;
+import io.gravitee.node.api.cluster.messaging.Topic;
+import io.gravitee.node.plugin.cache.standalone.StandaloneCacheManager;
+import io.gravitee.node.plugin.cluster.standalone.StandaloneClusterManager;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(VertxExtension.class)
+class PrimaryChannelManagerTest {
+
+    private CacheManager cacheManager;
+    private ClusterManager clusterManager;
+    private MockEnvironment environment;
+    private IdentifyConfiguration identifyConfiguration;
+    private PrimaryChannelManager cut;
+    private Cache<String, String> primaryChannelCache;
+    private Topic<PrimaryChannelElectedEvent> primaryChannelElectedEventTopic;
+    private Topic<PrimaryChannelEvictedEvent> primaryChannelEvictedEventTopic;
+    private Topic<ChannelEvent> primaryChannelEventTopic;
+
+    @BeforeEach
+    public void beforeEach(Vertx vertx) throws Exception {
+        environment = new MockEnvironment();
+        identifyConfiguration = new IdentifyConfiguration(environment);
+        cacheManager = new StandaloneCacheManager();
+        cacheManager.start();
+        clusterManager = new StandaloneClusterManager(vertx);
+        clusterManager.start();
+        cut = new PrimaryChannelManager(identifyConfiguration, clusterManager, cacheManager);
+        cut.start();
+
+        primaryChannelCache =
+            cacheManager.getOrCreateCache(
+                identifyConfiguration.identifyName(PRIMARY_CHANNEL_CACHE),
+                CacheConfiguration.builder().distributed(true).build()
+            );
+        primaryChannelEventTopic = clusterManager.topic(identifyConfiguration.identifyName(PRIMARY_CHANNEL_EVENTS_TOPIC));
+        primaryChannelElectedEventTopic = clusterManager.topic(identifyConfiguration.identifyName(PRIMARY_CHANNEL_EVENTS_ELECTED_TOPIC));
+        primaryChannelEvictedEventTopic = clusterManager.topic(identifyConfiguration.identifyName(PRIMARY_CHANNEL_EVENTS_EVICTED_TOPIC));
+    }
+
+    @AfterEach
+    public void afterEach() {
+        primaryChannelCache.clear();
+    }
+
+    @Test
+    void should_elect_new_primary_channel(VertxTestContext vertxTestContext) throws InterruptedException {
+        Checkpoint checkpoint = vertxTestContext.checkpoint();
+        primaryChannelElectedEventTopic.addMessageListener(message -> checkpoint.flag());
+        cut.sendChannelEvent(new SampleChannel("channelId", "targetId"), true);
+        assertThat(vertxTestContext.awaitCompletion(1, TimeUnit.SECONDS)).isTrue();
+        assertThat(primaryChannelCache.containsKey("targetId")).isTrue();
+        // should contain channel for the target
+        cut.primaryChannelBy("targetId").test().awaitDone(1, TimeUnit.SECONDS).assertValue("channelId");
+        // should have  primary channel for the target
+        cut
+            .candidatesChannel("targetId")
+            .test()
+            .awaitDone(1, TimeUnit.SECONDS)
+            .assertValue(candidates -> {
+                assertThat(candidates).containsOnly("channelId");
+                return true;
+            });
+    }
+
+    @Test
+    void should_elect_then_evict_primary_channel(VertxTestContext vertxTestContext) throws InterruptedException {
+        Checkpoint checkpoint = vertxTestContext.checkpoint(2);
+        primaryChannelElectedEventTopic.addMessageListener(message -> {
+            checkpoint.flag();
+            cut.sendChannelEvent(new SampleChannel("channelId", "targetId"), false);
+        });
+        primaryChannelEvictedEventTopic.addMessageListener(message -> checkpoint.flag());
+        cut.sendChannelEvent(new SampleChannel("channelId", "targetId"), true);
+
+        assertThat(vertxTestContext.awaitCompletion(1, TimeUnit.SECONDS)).isTrue();
+        // shouldn't contain any channel for the target
+        assertThat(primaryChannelCache.containsKey("targetId")).isFalse();
+        // shouldn't have any primary channel for the target
+        cut.primaryChannelBy("targetId").test().awaitDone(1, TimeUnit.SECONDS).assertNoValues();
+        cut.candidatesChannel("targetId").test().awaitDone(1, TimeUnit.SECONDS).assertNoValues();
+    }
+
+    @Test
+    void should_reelect_after_evicted_primary_channel(VertxTestContext vertxTestContext) throws InterruptedException {
+        AtomicInteger channelEventsCount = new AtomicInteger(0);
+        Checkpoint checkpoint = vertxTestContext.checkpoint(2);
+        primaryChannelElectedEventTopic.addMessageListener(message -> {
+            checkpoint.flag();
+            if (channelEventsCount.get() == 1) {
+                // Make sure to election of primary is done before sending new channel event
+                cut.sendChannelEvent(new SampleChannel("channelId2", "targetId"), true);
+            }
+        });
+
+        primaryChannelEventTopic.addMessageListener(message -> {
+            int count = channelEventsCount.incrementAndGet();
+            // Make sure to send the following event after the first two have been properly send
+            if (count == 2) {
+                cut.sendChannelEvent(new SampleChannel("channelId", "targetId"), false);
+            }
+        });
+
+        cut.sendChannelEvent(new SampleChannel("channelId", "targetId"), true);
+        assertThat(vertxTestContext.awaitCompletion(10, TimeUnit.SECONDS)).isTrue();
+        assertThat(primaryChannelCache.containsKey("targetId")).isTrue();
+        cut.primaryChannelBy("targetId").test().awaitDone(10, TimeUnit.SECONDS).assertValue("channelId2");
+        cut
+            .candidatesChannel("targetId")
+            .test()
+            .awaitDone(1, TimeUnit.SECONDS)
+            .assertValue(candidates -> {
+                assertThat(candidates).containsOnly("channelId2");
+                return true;
+            });
+    }
+
+    @Test
+    void should_not_listen_any_more_channel_event_after_stop(VertxTestContext vertxTestContext) throws Exception {
+        Checkpoint checkpoint = vertxTestContext.checkpoint();
+        primaryChannelElectedEventTopic.addMessageListener(message -> checkpoint.flag());
+        primaryChannelEventTopic.addMessageListener(message -> checkpoint.flag());
+        cut.stop();
+        cut.sendChannelEvent(new SampleChannel("channelId", "targetId"), true);
+        assertThat(vertxTestContext.awaitCompletion(10, TimeUnit.SECONDS)).isTrue();
+        assertThat(primaryChannelCache.containsKey("targetId")).isFalse();
+        cut.primaryChannelBy("targetId").test().awaitDone(10, TimeUnit.SECONDS).assertNoValues();
+        cut.candidatesChannel("targetId").test().awaitDone(1, TimeUnit.SECONDS).assertNoValues();
+    }
+}

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/cluster/ControllerClusterManagerTest.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/cluster/ControllerClusterManagerTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.exchange.controller.core.cluster;
+
+import static io.gravitee.exchange.controller.core.channel.primary.PrimaryChannelManager.PRIMARY_CHANNEL_EVENTS_TOPIC;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.exchange.api.command.Command;
+import io.gravitee.exchange.api.command.CommandHandler;
+import io.gravitee.exchange.api.command.Reply;
+import io.gravitee.exchange.api.command.goodbye.GoodByeCommand;
+import io.gravitee.exchange.api.command.goodbye.GoodByeReply;
+import io.gravitee.exchange.api.command.goodbye.GoodByeReplyPayload;
+import io.gravitee.exchange.api.configuration.IdentifyConfiguration;
+import io.gravitee.exchange.controller.core.channel.SampleChannel;
+import io.gravitee.exchange.controller.core.channel.primary.ChannelEvent;
+import io.gravitee.node.api.cache.CacheManager;
+import io.gravitee.node.api.cluster.messaging.Topic;
+import io.gravitee.node.plugin.cache.standalone.StandaloneCacheManager;
+import io.gravitee.node.plugin.cluster.standalone.StandaloneMember;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(VertxExtension.class)
+class ControllerClusterManagerTest {
+
+    private CacheManager cacheManager;
+    private MultiMemberStandaloneClusterManager clusterManager;
+    private MockEnvironment environment;
+    private IdentifyConfiguration identifyConfiguration;
+    private ControllerClusterManager cut;
+    private Topic<ChannelEvent> primaryChannelEventTopic;
+
+    @BeforeEach
+    public void beforeEach(Vertx vertx) throws Exception {
+        environment =
+            new MockEnvironment()
+                .withProperty("exchange.controller.auto-rebalancing.enabled", "true")
+                .withProperty("exchange.controller.auto-rebalancing.delay", "1000")
+                .withProperty("exchange.controller.auto-rebalancing.unit", "MILLISECONDS");
+        identifyConfiguration = new IdentifyConfiguration(environment);
+        cacheManager = new StandaloneCacheManager();
+        cacheManager.start();
+        clusterManager = new MultiMemberStandaloneClusterManager(vertx);
+        clusterManager.start();
+        cut = new ControllerClusterManager(identifyConfiguration, clusterManager, cacheManager);
+        cut.start();
+        primaryChannelEventTopic = clusterManager.topic(identifyConfiguration.identifyName(PRIMARY_CHANNEL_EVENTS_TOPIC));
+    }
+
+    @Test
+    void should_not_rebalance_with_only_member(VertxTestContext vertxTestContext) throws InterruptedException {
+        Checkpoint checkpoint = vertxTestContext.checkpoint(2);
+        primaryChannelEventTopic.addMessageListener(message -> checkpoint.flag());
+        SampleChannel sampleChannel = new SampleChannel("channelId", "targetId", true);
+        sampleChannel.setClose(Completable.fromRunnable(checkpoint::flag));
+        SampleChannel sampleChannel2 = new SampleChannel("channelId2", "targetId", true);
+        sampleChannel2.setClose(Completable.fromRunnable(checkpoint::flag));
+        cut.register(sampleChannel).andThen(cut.register(sampleChannel2)).test().awaitDone(10, TimeUnit.SECONDS);
+        clusterManager.addMember(new StandaloneMember());
+        assertThat(vertxTestContext.awaitCompletion(10, TimeUnit.SECONDS)).isTrue();
+    }
+
+    @Test
+    void should_rebalance_channels_when_new_member_join(VertxTestContext vertxTestContext) throws InterruptedException {
+        AtomicInteger channelEventsCount = new AtomicInteger(0);
+        // 4 checkpoints:
+        //   - 1 for channel id alive
+        //   - 1 for channel id2 alive
+        //   - 1 for channel id2 close
+        //   - 1 for channel id2 not alive
+        Checkpoint checkpoint = vertxTestContext.checkpoint(4);
+        primaryChannelEventTopic.addMessageListener(message -> {
+            checkpoint.flag();
+            if (channelEventsCount.incrementAndGet() == 1) {
+                clusterManager.addMember(new StandaloneMember());
+            }
+        });
+        clusterManager.addMember(new StandaloneMember());
+        SampleChannel sampleChannel = new SampleChannel("channelId", "targetId", true);
+        sampleChannel.setClose(Completable.fromRunnable(checkpoint::flag));
+        SampleChannel sampleChannel2 = new SampleChannel("channelId2", "targetId", true);
+        sampleChannel2.setClose(Completable.fromRunnable(checkpoint::flag));
+        cut.register(sampleChannel).andThen(cut.register(sampleChannel2)).test().awaitDone(10, TimeUnit.SECONDS);
+        assertThat(vertxTestContext.awaitCompletion(10, TimeUnit.SECONDS)).isTrue();
+    }
+
+    @Test
+    void should_rebalance_channels_only_once_when_multiple_member_join_before_delay(VertxTestContext vertxTestContext)
+        throws InterruptedException {
+        AtomicInteger channelEventsCount = new AtomicInteger(0);
+        // 4 checkpoints:
+        //   - 1 for channel id alive
+        //   - 1 for channel id2 alive
+        //   - 1 for channel id2 close
+        //   - 1 for channel id2 not alive
+        Checkpoint checkpoint = vertxTestContext.checkpoint(4);
+        primaryChannelEventTopic.addMessageListener(message -> {
+            checkpoint.flag();
+            if (channelEventsCount.incrementAndGet() == 1) {
+                clusterManager.addMember(new StandaloneMember());
+                clusterManager.addMember(new StandaloneMember());
+                clusterManager.addMember(new StandaloneMember());
+                clusterManager.addMember(new StandaloneMember());
+            }
+        });
+        clusterManager.addMember(new StandaloneMember());
+        SampleChannel sampleChannel = new SampleChannel("channelId", "targetId", true);
+        sampleChannel.setClose(Completable.fromRunnable(checkpoint::flag));
+        SampleChannel sampleChannel2 = new SampleChannel("channelId2", "targetId", true);
+        sampleChannel2.setClose(Completable.fromRunnable(checkpoint::flag));
+        cut.register(sampleChannel).andThen(cut.register(sampleChannel2)).test().awaitDone(10, TimeUnit.SECONDS);
+        assertThat(vertxTestContext.awaitCompletion(10, TimeUnit.SECONDS)).isTrue();
+    }
+}

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/cluster/MultiMemberStandaloneClusterManager.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/cluster/MultiMemberStandaloneClusterManager.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.exchange.controller.core.cluster;
+
+import io.gravitee.node.api.cluster.Member;
+import io.gravitee.node.api.cluster.MemberListener;
+import io.gravitee.node.plugin.cluster.standalone.StandaloneClusterManager;
+import io.vertx.core.Vertx;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class MultiMemberStandaloneClusterManager extends StandaloneClusterManager {
+
+    private final Set<Member> members = new HashSet<>();
+    private final List<MemberListener> memberListeners = new ArrayList<>();
+
+    public MultiMemberStandaloneClusterManager(final Vertx vertx) {
+        super(vertx);
+    }
+
+    @Override
+    public void addMemberListener(final MemberListener listener) {
+        memberListeners.add(listener);
+    }
+
+    @Override
+    public void removeMemberListener(final MemberListener listener) {
+        memberListeners.remove(listener);
+    }
+
+    @Override
+    public Set<Member> members() {
+        return members;
+    }
+
+    public void addMember(Member member) {
+        members.add(member);
+        memberListeners.forEach(memberListener -> memberListener.onMemberAdded(member));
+    }
+
+    public void removeMember(Member member) {
+        members.remove(member);
+        memberListeners.forEach(memberListener -> memberListener.onMemberRemoved(member));
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-211

**Description**

Implement a mechanism when a new member joins the cluster in order to check if we should rebalance (close with reconnect) channels to properly divide them accross the cluster.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.6.0-add-rescalling-mechanism-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/exchange/gravitee-exchange/1.6.0-add-rescalling-mechanism-SNAPSHOT/gravitee-exchange-1.6.0-add-rescalling-mechanism-SNAPSHOT.zip)
  <!-- Version placeholder end -->
