### PR TITLE
fix: add debug log when command reply received

### DIFF
--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/channel/AbstractWebSocketChannel.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/channel/AbstractWebSocketChannel.java
@@ -394,6 +394,9 @@ public abstract class AbstractWebSocketChannel implements Channel {
                         resultEmitters.put(adaptedCommand.getId(), emitter);
                         writeCommand(adaptedCommand).doOnError(emitter::onError).onErrorComplete().subscribe();
                     })
+                    .doOnSuccess(reply -> {
+                        log.debug("Command reply received for command [{}, {}]", adaptedCommand.getType(), adaptedCommand.getId());
+                    })
                     .timeout(
                         adaptedCommand.getReplyTimeoutMs(),
                         TimeUnit.MILLISECONDS,
@@ -428,6 +431,7 @@ public abstract class AbstractWebSocketChannel implements Channel {
             .exchangeType(command.getType())
             .exchange(command)
             .build();
+
         return writeToSocket(command.getId(), protocolExchange);
     }
 


### PR DESCRIPTION
**Issue**

Link to the original issue

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.6.2-add-logs-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/exchange/gravitee-exchange/1.6.2-add-logs-SNAPSHOT/gravitee-exchange-1.6.2-add-logs-SNAPSHOT.zip)
  <!-- Version placeholder end -->
