### PR TITLE
feat: add management endpoint on core api

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -40,3 +40,21 @@ image::docs/sending-command.png[width=1125]
 The purpose of health check is to verify that the connector is still properly working and able to receive commands, at network level and also at the business logic level. The connector can do business check to ensure it can react on any commands.
 
 image::docs/health-check.png[width=1125]
+
+== Management API
+By default, when a controller is created it will register endpoints on the Node Management API. See https://github.com/gravitee-io/gravitee-node/blob/master/README.adoc#management.
+
+The endpoints are the following, where `[identifier]` is optional and will be your controller identifier:
+
+    - `/exchange/[identifier]/targets`: return metrics information on channels and batchs grouped by target.
+    - `/exchange/[identifier]/targets/:id`: return metrics information on channels and batchs for the given target.
+    - `/exchange/[identifier]/targets/:id/channels`: return metrics information on channels for the given target.
+    - `/exchange/[identifier]/targets/:id/batchs`: return metrics information on batchs for the given target.
+    - `/exchange/[identifier]/batchs`: return metrics information on batchs. Can be filtered by `status` and `targetId`.
+    - `/exchange/[identifier]/batchs/:id`: return metrics information for the given batch.
+    - `/exchange/[identifier]/channels`: list channels. Can be filtered by `active` status and `targetId`.
+    - `/exchange/[identifier]/channels/:id`: return metrics information for the given channel.
+
+=== Deactivation
+
+This behavior can be disabled by settings the following property `[identifier].controller.management.enabled` to `false`. The `[identifier]` is your controller identifier or `exchange` by default.

--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/controller/ExchangeController.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/controller/ExchangeController.java
@@ -22,10 +22,13 @@ import io.gravitee.exchange.api.batch.KeyBatchObserver;
 import io.gravitee.exchange.api.command.Command;
 import io.gravitee.exchange.api.command.Reply;
 import io.gravitee.exchange.api.controller.listeners.TargetListener;
+import io.gravitee.exchange.api.controller.metrics.BatchMetric;
 import io.gravitee.exchange.api.controller.metrics.ChannelMetric;
-import io.gravitee.exchange.api.controller.metrics.TargetMetric;
+import io.gravitee.exchange.api.controller.metrics.TargetBatchsMetric;
+import io.gravitee.exchange.api.controller.metrics.TargetChannelsMetric;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 
 /**
@@ -46,19 +49,50 @@ public interface ExchangeController extends Service<ExchangeController> {
     ExchangeController removeListener(TargetListener targetListener);
 
     /**
-     * Return all target metrics
+     * Return batchs metrics grouped by target
      *
-     * @return target metrics.
+     * @return batchs metrics by target
      */
-    Flowable<TargetMetric> targetsMetric();
+    Flowable<TargetBatchsMetric> batchsMetricsByTarget();
 
     /**
-     * Return all channel metrics for the given target
+     * Return all batchs metrics for the given target
+     *
+     * @param targetId the target id to retrieve batchs metrics
+     * @return batchs metrics.
+     */
+    Flowable<BatchMetric> batchsMetricsForTarget(String targetId);
+
+    /**
+     * Return batch metric for the given id
+     *
+     * @param batchId the batch id to retrieve
+     * @return batch metric.
+     */
+    Maybe<BatchMetric> batchMetric(String batchId);
+
+    /**
+     * Return channels metrics grouped by target
+     *
+     * @return channel metrics by target
+     */
+    Flowable<TargetChannelsMetric> channelsMetricsByTarget();
+
+    /**
+     * Return channel metrics for the given target
      *
      * @param targetId the target id to retrieve channel metrics
      * @return channel metrics.
      */
-    Flowable<ChannelMetric> channelsMetric(String targetId);
+    Flowable<ChannelMetric> channelsMetricsForTarget(String targetId);
+
+    /**
+     * Return channel metric for the given id
+     *
+     * @param channelId the channel id to retrieve
+     * @return channel metric.
+     */
+    Maybe<ChannelMetric> channelMetric(String channelId);
 
     /**
      * Register a new {@code ControllerChannel} on this controller

--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/controller/metrics/BatchMetric.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/controller/metrics/BatchMetric.java
@@ -15,11 +15,32 @@
  */
 package io.gravitee.exchange.api.controller.metrics;
 
+import io.gravitee.exchange.api.batch.Batch;
+import io.gravitee.exchange.api.batch.BatchStatus;
+import java.time.Instant;
 import lombok.Builder;
 
-/**
- * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
- * @author GraviteeSource Team
- */
 @Builder
-public record ChannelMetric(String id, String targetId, boolean active, boolean pendingCommands, boolean primary) {}
+public record BatchMetric(
+    String id,
+    String key,
+    String targetId,
+    BatchStatus status,
+    String errorDetails,
+    Integer maxRetry,
+    Integer retry,
+    Instant lastRetryAt
+) {
+    public BatchMetric(Batch batch) {
+        this(
+            batch.id(),
+            batch.key(),
+            batch.targetId(),
+            batch.status(),
+            batch.errorDetails(),
+            batch.maxRetry(),
+            batch.retry(),
+            batch.lastRetryAt()
+        );
+    }
+}

--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/controller/metrics/TargetBatchsMetric.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/controller/metrics/TargetBatchsMetric.java
@@ -16,21 +16,11 @@
 package io.gravitee.exchange.api.controller.metrics;
 
 import java.util.List;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.experimental.Accessors;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
 @Builder
-@AllArgsConstructor
-@Getter
-@Accessors(fluent = true, chain = true)
-public class TargetMetric {
-
-    String id;
-    List<ChannelMetric> channelMetrics;
-}
+public record TargetBatchsMetric(String id, List<BatchMetric> batchs) {}

--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/controller/metrics/TargetChannelsMetric.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/controller/metrics/TargetChannelsMetric.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.exchange.api.controller.metrics;
 
+import java.util.List;
 import lombok.Builder;
 
 /**
@@ -22,4 +23,4 @@ import lombok.Builder;
  * @author GraviteeSource Team
  */
 @Builder
-public record ChannelMetric(String id, String targetId, boolean active, boolean pendingCommands, boolean primary) {}
+public record TargetChannelsMetric(String id, List<ChannelMetric> channels) {}

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/pom.xml
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/pom.xml
@@ -47,6 +47,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-management</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <scope>provided</scope>

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/batch/BatchStore.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/batch/BatchStore.java
@@ -40,6 +40,10 @@ public class BatchStore {
         store.clear();
     }
 
+    public Flowable<Batch> getAll() {
+        return store.rxValues().subscribeOn(Schedulers.io());
+    }
+
     public Maybe<Batch> getById(String id) {
         return Maybe
             .fromCallable(() -> {

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/management/ControllerTargetIdMetricsEndpoint.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/management/ControllerTargetIdMetricsEndpoint.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.exchange.controller.core.management;
+
+import static io.gravitee.exchange.controller.core.management.EndpointHelper.write;
+
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.exchange.api.configuration.IdentifyConfiguration;
+import io.gravitee.exchange.api.controller.ExchangeController;
+import io.gravitee.exchange.api.controller.metrics.BatchMetric;
+import io.gravitee.exchange.api.controller.metrics.ChannelMetric;
+import io.gravitee.exchange.controller.core.management.error.ManagementError;
+import io.gravitee.node.management.http.endpoint.ManagementEndpoint;
+import io.vertx.ext.web.RoutingContext;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+public class ControllerTargetIdMetricsEndpoint implements ManagementEndpoint {
+
+    private final IdentifyConfiguration identifyConfiguration;
+    private final ExchangeController exchangeController;
+
+    @Override
+    public HttpMethod method() {
+        return HttpMethod.GET;
+    }
+
+    @Override
+    public String path() {
+        return EndpointHelper.path(identifyConfiguration, "/targets/:targetId");
+    }
+
+    @Override
+    public void handle(final RoutingContext ctx) {
+        var targetId = ctx.pathParam("targetId");
+        exchangeController
+            .channelsMetricsForTarget(targetId)
+            .toList()
+            .map(Result::new)
+            .flatMap(result ->
+                exchangeController
+                    .batchsMetricsForTarget(targetId)
+                    .toList()
+                    .doOnSuccess(batchMetrics -> result.batchs().addAll(batchMetrics))
+                    .map(batchMetrics -> result)
+            )
+            .doOnSuccess(result -> {
+                if (result.channels.isEmpty() && result.batchs.isEmpty()) {
+                    write(
+                        ctx,
+                        ManagementError
+                            .builder()
+                            .code(404)
+                            .message("No metrics found for the given target [%s]".formatted(targetId))
+                            .build()
+                    );
+                } else {
+                    write(ctx, result);
+                }
+            })
+            .doOnError(throwable -> {
+                log.error(
+                    "[{}] Unable to retrieve target metrics for the given target '{}'",
+                    identifyConfiguration.id(),
+                    targetId,
+                    throwable
+                );
+                write(
+                    ctx,
+                    ManagementError
+                        .builder()
+                        .code(500)
+                        .message("Unable to retrieve target metrics for the given target [%s]".formatted(targetId))
+                        .build()
+                );
+            })
+            .onErrorComplete()
+            .subscribe();
+    }
+
+    public record Result(List<ChannelMetric> channels, List<BatchMetric> batchs) {
+        public Result(List<ChannelMetric> channels) {
+            this(channels, new ArrayList<>());
+        }
+    }
+}

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/management/ControllerTargetsMetricsEndpoint.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/management/ControllerTargetsMetricsEndpoint.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.exchange.controller.core.management;
+
+import static io.gravitee.exchange.controller.core.management.EndpointHelper.write;
+
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.exchange.api.configuration.IdentifyConfiguration;
+import io.gravitee.exchange.api.controller.ExchangeController;
+import io.gravitee.exchange.api.controller.metrics.BatchMetric;
+import io.gravitee.exchange.api.controller.metrics.ChannelMetric;
+import io.gravitee.exchange.controller.core.management.error.ManagementError;
+import io.gravitee.node.management.http.endpoint.ManagementEndpoint;
+import io.vertx.ext.web.RoutingContext;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+public class ControllerTargetsMetricsEndpoint implements ManagementEndpoint {
+
+    private final IdentifyConfiguration identifyConfiguration;
+    private final ExchangeController exchangeController;
+
+    @Override
+    public HttpMethod method() {
+        return HttpMethod.GET;
+    }
+
+    @Override
+    public String path() {
+        return EndpointHelper.path(identifyConfiguration, "/targets");
+    }
+
+    @Override
+    public void handle(final RoutingContext ctx) {
+        exchangeController
+            .channelsMetricsByTarget()
+            .map(targetMetric -> new Result(targetMetric.id(), targetMetric.channels()))
+            .zipWith(
+                exchangeController.batchsMetricsByTarget().cache(),
+                (result, targetBatchsMetrics) -> {
+                    if (result.id.equals(targetBatchsMetrics.id())) {
+                        result.batchs.addAll(targetBatchsMetrics.batchs());
+                    }
+                    return result;
+                }
+            )
+            .toList()
+            .doOnSuccess(results -> write(ctx, results))
+            .doOnError(throwable -> {
+                log.error("[{}] Unable to retrieve targets metrics", identifyConfiguration.id(), throwable);
+                write(ctx, ManagementError.builder().code(500).message("Unable to retrieve targets metrics").build());
+            })
+            .onErrorComplete()
+            .subscribe();
+    }
+
+    public record Result(String id, List<ChannelMetric> channels, List<BatchMetric> batchs) {
+        public Result(String id, List<ChannelMetric> channels) {
+            this(id, channels, new ArrayList<>());
+        }
+    }
+}

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/management/EndpointHelper.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/management/EndpointHelper.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.exchange.controller.core.management;
+
+import static io.gravitee.exchange.api.configuration.IdentifyConfiguration.DEFAULT_EXCHANGE_ID;
+
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.exchange.api.configuration.IdentifyConfiguration;
+import io.gravitee.exchange.controller.core.management.error.ManagementError;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.json.Json;
+import io.vertx.ext.web.RoutingContext;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class EndpointHelper {
+
+    public static String path(final IdentifyConfiguration identifyConfiguration, final String path) {
+        StringBuilder builder = new StringBuilder("/exchange");
+        String id = identifyConfiguration.id();
+        if (!DEFAULT_EXCHANGE_ID.equals(id)) {
+            builder.append("/%s".formatted(id));
+        }
+        return builder.append(path).toString();
+    }
+
+    public static <T> void write(final RoutingContext ctx, final T payload) {
+        ctx
+            .response()
+            .setStatusCode(HttpStatusCode.OK_200)
+            .putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+            .end(Json.encodePrettily(payload));
+    }
+
+    public static void write(final RoutingContext ctx, final ManagementError exchangeManagementError) {
+        ctx
+            .response()
+            .setStatusCode(exchangeManagementError.code())
+            .putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+            .end(Json.encodePrettily(exchangeManagementError));
+    }
+}

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/management/batch/ControllerBatchMetricsEndpoint.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/management/batch/ControllerBatchMetricsEndpoint.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.exchange.controller.core.management.batch;
+
+import static io.gravitee.exchange.controller.core.management.EndpointHelper.write;
+
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.exchange.api.configuration.IdentifyConfiguration;
+import io.gravitee.exchange.api.controller.ExchangeController;
+import io.gravitee.exchange.controller.core.management.EndpointHelper;
+import io.gravitee.exchange.controller.core.management.error.ManagementError;
+import io.gravitee.node.management.http.endpoint.ManagementEndpoint;
+import io.vertx.ext.web.RoutingContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+public class ControllerBatchMetricsEndpoint implements ManagementEndpoint {
+
+    private final IdentifyConfiguration identifyConfiguration;
+    private final ExchangeController exchangeController;
+
+    @Override
+    public HttpMethod method() {
+        return HttpMethod.GET;
+    }
+
+    @Override
+    public String path() {
+        return EndpointHelper.path(identifyConfiguration, "/batchs/:batchId");
+    }
+
+    @Override
+    public void handle(final RoutingContext ctx) {
+        var batchId = ctx.pathParam("batchId");
+        exchangeController
+            .batchMetric(batchId)
+            .doOnSuccess(batchMetric -> write(ctx, batchMetric))
+            .doOnComplete(() ->
+                write(ctx, ManagementError.builder().code(404).message("No batch found for the given id [%s]".formatted(batchId)).build())
+            )
+            .doOnError(throwable -> {
+                log.error("[{}] Unable to retrieve batch metrics for the given id '{}'", identifyConfiguration.id(), batchId, throwable);
+                write(
+                    ctx,
+                    ManagementError
+                        .builder()
+                        .code(500)
+                        .message("Unable to retrieve batch metrics for the given id [%s]".formatted(batchId))
+                        .build()
+                );
+            })
+            .onErrorComplete()
+            .subscribe();
+    }
+}

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/management/batch/ControllerBatchsMetricsEndpoint.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/management/batch/ControllerBatchsMetricsEndpoint.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.exchange.controller.core.management.batch;
+
+import static io.gravitee.exchange.controller.core.management.EndpointHelper.write;
+
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.exchange.api.configuration.IdentifyConfiguration;
+import io.gravitee.exchange.api.controller.ExchangeController;
+import io.gravitee.exchange.controller.core.management.EndpointHelper;
+import io.gravitee.exchange.controller.core.management.error.ManagementError;
+import io.gravitee.node.management.http.endpoint.ManagementEndpoint;
+import io.vertx.ext.web.RoutingContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+public class ControllerBatchsMetricsEndpoint implements ManagementEndpoint {
+
+    private final IdentifyConfiguration identifyConfiguration;
+    private final ExchangeController exchangeController;
+
+    @Override
+    public HttpMethod method() {
+        return HttpMethod.GET;
+    }
+
+    @Override
+    public String path() {
+        return EndpointHelper.path(identifyConfiguration, "/batchs");
+    }
+
+    @Override
+    public void handle(final RoutingContext ctx) {
+        var status = ctx.request().getParam("status");
+        var targetId = ctx.request().getParam("targetId");
+        exchangeController
+            .batchsMetricsByTarget()
+            .filter(targetBatchsMetric ->
+                (targetId == null || targetId.equals(targetBatchsMetric.id())) &&
+                (
+                    status == null ||
+                    targetBatchsMetric.batchs().stream().anyMatch(batchMetric -> batchMetric.status().name().equalsIgnoreCase(status))
+                )
+            )
+            .flatMapStream(targetBatchsMetric -> targetBatchsMetric.batchs().stream())
+            .toList()
+            .doOnSuccess(batchsMetric -> write(ctx, batchsMetric))
+            .doOnError(throwable -> {
+                log.error("[{}] Unable to retrieve batchs metrics", identifyConfiguration.id(), throwable);
+                write(ctx, ManagementError.builder().code(500).message("Unable to retrieve batchs metrics").build());
+            })
+            .onErrorComplete()
+            .subscribe();
+    }
+}

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/management/batch/ControllerTargetIdBatchsMetricsEndpoint.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/management/batch/ControllerTargetIdBatchsMetricsEndpoint.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.exchange.controller.core.management.batch;
+
+import static io.gravitee.exchange.controller.core.management.EndpointHelper.write;
+
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.exchange.api.configuration.IdentifyConfiguration;
+import io.gravitee.exchange.api.controller.ExchangeController;
+import io.gravitee.exchange.controller.core.management.EndpointHelper;
+import io.gravitee.exchange.controller.core.management.error.ManagementError;
+import io.gravitee.node.management.http.endpoint.ManagementEndpoint;
+import io.vertx.ext.web.RoutingContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+public class ControllerTargetIdBatchsMetricsEndpoint implements ManagementEndpoint {
+
+    private final IdentifyConfiguration identifyConfiguration;
+    private final ExchangeController exchangeController;
+
+    @Override
+    public HttpMethod method() {
+        return HttpMethod.GET;
+    }
+
+    @Override
+    public String path() {
+        return EndpointHelper.path(identifyConfiguration, "/targets/:targetId/batchs");
+    }
+
+    @Override
+    public void handle(final RoutingContext ctx) {
+        var targetId = ctx.pathParam("targetId");
+        exchangeController
+            .batchsMetricsForTarget(targetId)
+            .toList()
+            .doOnSuccess(batchsMetric -> write(ctx, batchsMetric))
+            .doOnError(throwable -> {
+                log.error(
+                    "[{}] Unable to retrieve batchs metrics for the given target '{}'",
+                    identifyConfiguration.id(),
+                    targetId,
+                    throwable
+                );
+                write(
+                    ctx,
+                    ManagementError
+                        .builder()
+                        .code(500)
+                        .message("Unable to retrieve batchs metrics for the given target [%s]".formatted(targetId))
+                        .build()
+                );
+            })
+            .onErrorComplete()
+            .subscribe();
+    }
+}

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/management/channel/ControllerChannelMetricsEndpoint.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/management/channel/ControllerChannelMetricsEndpoint.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.exchange.controller.core.management.channel;
+
+import static io.gravitee.exchange.controller.core.management.EndpointHelper.write;
+
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.exchange.api.configuration.IdentifyConfiguration;
+import io.gravitee.exchange.api.controller.ExchangeController;
+import io.gravitee.exchange.controller.core.management.EndpointHelper;
+import io.gravitee.exchange.controller.core.management.error.ManagementError;
+import io.gravitee.node.management.http.endpoint.ManagementEndpoint;
+import io.vertx.ext.web.RoutingContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+public class ControllerChannelMetricsEndpoint implements ManagementEndpoint {
+
+    private final IdentifyConfiguration identifyConfiguration;
+    private final ExchangeController exchangeController;
+
+    @Override
+    public HttpMethod method() {
+        return HttpMethod.GET;
+    }
+
+    @Override
+    public String path() {
+        return EndpointHelper.path(identifyConfiguration, "/channels/:channelId");
+    }
+
+    @Override
+    public void handle(final RoutingContext ctx) {
+        var channelId = ctx.pathParam("channelId");
+        exchangeController
+            .channelMetric(channelId)
+            .doOnSuccess(batchMetric -> write(ctx, batchMetric))
+            .doOnComplete(() ->
+                write(
+                    ctx,
+                    ManagementError.builder().code(404).message("No channel found for the given id [%s]".formatted(channelId)).build()
+                )
+            )
+            .doOnError(throwable -> {
+                log.error(
+                    "[{}] Unable to retrieve channels metrics for the given id '{}'",
+                    identifyConfiguration.id(),
+                    channelId,
+                    throwable
+                );
+                write(
+                    ctx,
+                    ManagementError
+                        .builder()
+                        .code(500)
+                        .message("Unable to retrieve channel metrics for the given id [%s]".formatted(channelId))
+                        .build()
+                );
+            })
+            .onErrorComplete()
+            .subscribe();
+    }
+}

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/management/channel/ControllerChannelsMetricsEndpoint.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/management/channel/ControllerChannelsMetricsEndpoint.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.exchange.controller.core.management.channel;
+
+import static io.gravitee.exchange.controller.core.management.EndpointHelper.write;
+
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.exchange.api.configuration.IdentifyConfiguration;
+import io.gravitee.exchange.api.controller.ExchangeController;
+import io.gravitee.exchange.controller.core.management.EndpointHelper;
+import io.gravitee.exchange.controller.core.management.error.ManagementError;
+import io.gravitee.node.management.http.endpoint.ManagementEndpoint;
+import io.vertx.ext.web.RoutingContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+public class ControllerChannelsMetricsEndpoint implements ManagementEndpoint {
+
+    private final IdentifyConfiguration identifyConfiguration;
+    private final ExchangeController exchangeController;
+
+    @Override
+    public HttpMethod method() {
+        return HttpMethod.GET;
+    }
+
+    @Override
+    public String path() {
+        return EndpointHelper.path(identifyConfiguration, "/channels");
+    }
+
+    @Override
+    public void handle(final RoutingContext ctx) {
+        var active = ctx.request().getParam("active");
+        var targetId = ctx.request().getParam("targetId");
+        exchangeController
+            .channelsMetricsByTarget()
+            .filter(targetChannelsMetric ->
+                (targetId == null || targetId.equals(targetChannelsMetric.id())) &&
+                (
+                    active == null ||
+                    targetChannelsMetric.channels().stream().anyMatch(batchMetric -> batchMetric.active() == Boolean.parseBoolean(active))
+                )
+            )
+            .flatMapStream(targetChannelsMetric -> targetChannelsMetric.channels().stream())
+            .toList()
+            .doOnSuccess(channelMetrics -> write(ctx, channelMetrics))
+            .doOnError(throwable -> {
+                log.error("[{}] Unable to retrieve channels metrics", identifyConfiguration.id(), throwable);
+                write(ctx, ManagementError.builder().code(500).message("Unable to retrieve channels metrics").build());
+            })
+            .onErrorComplete()
+            .subscribe();
+    }
+}

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/management/channel/ControllerTargetIdChannelsMetricsEndpoint.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/management/channel/ControllerTargetIdChannelsMetricsEndpoint.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.exchange.controller.core.management.channel;
+
+import static io.gravitee.exchange.controller.core.management.EndpointHelper.write;
+
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.exchange.api.configuration.IdentifyConfiguration;
+import io.gravitee.exchange.api.controller.ExchangeController;
+import io.gravitee.exchange.controller.core.management.EndpointHelper;
+import io.gravitee.exchange.controller.core.management.error.ManagementError;
+import io.gravitee.node.management.http.endpoint.ManagementEndpoint;
+import io.vertx.ext.web.RoutingContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+public class ControllerTargetIdChannelsMetricsEndpoint implements ManagementEndpoint {
+
+    private final IdentifyConfiguration identifyConfiguration;
+    private final ExchangeController exchangeController;
+
+    @Override
+    public HttpMethod method() {
+        return HttpMethod.GET;
+    }
+
+    @Override
+    public String path() {
+        return EndpointHelper.path(identifyConfiguration, "/targets/:targetId/channels");
+    }
+
+    @Override
+    public void handle(final RoutingContext ctx) {
+        var targetId = ctx.pathParam("targetId");
+        exchangeController
+            .channelsMetricsForTarget(targetId)
+            .toList()
+            .doOnSuccess(channelMetrics -> write(ctx, channelMetrics))
+            .doOnError(throwable -> {
+                log.error(
+                    "[{}] Unable to retrieve channels metrics for the given target id '{}'",
+                    identifyConfiguration.id(),
+                    targetId,
+                    throwable
+                );
+                write(
+                    ctx,
+                    ManagementError
+                        .builder()
+                        .code(500)
+                        .message("Unable to retrieve channels metrics for the given target id [%s]".formatted(targetId))
+                        .build()
+                );
+            })
+            .onErrorComplete()
+            .subscribe();
+    }
+}

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/management/error/ManagementError.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/management/error/ManagementError.java
@@ -13,13 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.exchange.api.controller.metrics;
+package io.gravitee.exchange.controller.core.management.error;
 
 import lombok.Builder;
 
-/**
- * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
- * @author GraviteeSource Team
- */
 @Builder
-public record ChannelMetric(String id, String targetId, boolean active, boolean pendingCommands, boolean primary) {}
+public record ManagementError(int code, String message) {}

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/DefaultExchangeControllerTest.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/DefaultExchangeControllerTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.exchange.controller.core;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.gravitee.exchange.api.configuration.IdentifyConfiguration;
+import io.gravitee.node.api.cache.Cache;
+import io.gravitee.node.api.cache.CacheManager;
+import io.gravitee.node.api.cluster.ClusterManager;
+import io.gravitee.node.api.cluster.Member;
+import io.gravitee.node.api.cluster.messaging.Queue;
+import io.gravitee.node.api.cluster.messaging.Topic;
+import io.gravitee.node.management.http.endpoint.ManagementEndpointManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class DefaultExchangeControllerTest {
+
+    @Mock
+    private ClusterManager clusterManager;
+
+    @Mock
+    private CacheManager cacheManager;
+
+    @Mock
+    private ManagementEndpointManager managementEndpointManager;
+
+    private MockEnvironment environment;
+    private DefaultExchangeController cut;
+
+    @BeforeEach
+    public void beforeEach() {
+        lenient().when(clusterManager.topic(any())).thenReturn(mock(Topic.class));
+        lenient().when(clusterManager.queue(any())).thenReturn(mock(Queue.class));
+        Member member = mock(Member.class);
+        lenient().when(member.primary()).thenReturn(true);
+        lenient().when(clusterManager.self()).thenReturn(member);
+
+        lenient().when(cacheManager.getOrCreateCache(any(), any())).thenReturn(mock(Cache.class));
+        environment = new MockEnvironment();
+        cut =
+            new DefaultExchangeController(new IdentifyConfiguration(environment), clusterManager, cacheManager, managementEndpointManager);
+    }
+
+    @Test
+    void should_not_register_any_endpoints_management_when_disabled() throws Exception {
+        environment.withProperty("exchange.controller.management.enabled", "false");
+        cut =
+            new DefaultExchangeController(new IdentifyConfiguration(environment), clusterManager, cacheManager, managementEndpointManager);
+        cut.start();
+        verify(managementEndpointManager, never()).register(any());
+    }
+
+    @Test
+    void should_not_register_any_endpoints_management_when_manager_is_null() {
+        cut = new DefaultExchangeController(new IdentifyConfiguration(environment), clusterManager, cacheManager);
+        assertDoesNotThrow(() -> cut.start());
+    }
+
+    @Test
+    void should_register_endpoints_management() throws Exception {
+        cut.start();
+        verify(managementEndpointManager, times(8)).register(any());
+    }
+
+    @Test
+    void should_register_only_channels_endpoints_management_when_batch_feature_is_disabled() throws Exception {
+        environment.withProperty("exchange.controller.batch.enabled", "false");
+        cut =
+            new DefaultExchangeController(new IdentifyConfiguration(environment), clusterManager, cacheManager, managementEndpointManager);
+        cut.start();
+        verify(managementEndpointManager, times(5)).register(any());
+    }
+
+    @Test
+    void should_unregister_endpoints_management() throws Exception {
+        cut.start();
+        verify(managementEndpointManager, times(8)).register(any());
+        cut.stop();
+        verify(managementEndpointManager, times(8)).unregister(any());
+    }
+}

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/channel/ChannelManagerTest.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/channel/ChannelManagerTest.java
@@ -33,7 +33,7 @@ import io.gravitee.exchange.api.command.primary.PrimaryReply;
 import io.gravitee.exchange.api.command.primary.PrimaryReplyPayload;
 import io.gravitee.exchange.api.configuration.IdentifyConfiguration;
 import io.gravitee.exchange.api.controller.metrics.ChannelMetric;
-import io.gravitee.exchange.api.controller.metrics.TargetMetric;
+import io.gravitee.exchange.api.controller.metrics.TargetChannelsMetric;
 import io.gravitee.exchange.controller.core.channel.exception.NoChannelFoundException;
 import io.gravitee.exchange.controller.core.channel.primary.ChannelEvent;
 import io.gravitee.node.api.cache.CacheManager;
@@ -236,18 +236,18 @@ class ChannelManagerTest {
         assertThat(vertxTestContext.awaitCompletion(10, TimeUnit.SECONDS)).isTrue();
 
         cut
-            .targetsMetric()
+            .channelsMetricsByTarget()
             .toList()
             .test()
             .awaitDone(10, TimeUnit.SECONDS)
             .assertValue(targetMetrics -> {
-                for (TargetMetric targetMetric : targetMetrics) {
-                    if (targetMetric.id().equals("targetId")) {
-                        assertThat(targetMetric.channelMetrics())
+                for (TargetChannelsMetric targetChannelsMetric : targetMetrics) {
+                    if (targetChannelsMetric.id().equals("targetId")) {
+                        assertThat(targetChannelsMetric.channels())
                             .extracting(ChannelMetric::id, ChannelMetric::primary, ChannelMetric::active)
                             .containsOnly(Tuple.tuple("channelId", true, true), Tuple.tuple("channelId2", false, false));
-                    } else if (targetMetric.id().equals("targetId2")) {
-                        assertThat(targetMetric.channelMetrics())
+                    } else if (targetChannelsMetric.id().equals("targetId2")) {
+                        assertThat(targetChannelsMetric.channels())
                             .extracting(ChannelMetric::id, ChannelMetric::primary, ChannelMetric::active)
                             .containsOnly(Tuple.tuple("channelId3", true, true));
                     } else {
@@ -275,7 +275,7 @@ class ChannelManagerTest {
         assertThat(vertxTestContext.awaitCompletion(10, TimeUnit.SECONDS)).isTrue();
 
         cut
-            .channelsMetric("targetId")
+            .channelsMetricsForTarget("targetId")
             .toList()
             .test()
             .awaitDone(10, TimeUnit.SECONDS)

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/management/AbstractMetricEndpointTest.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/management/AbstractMetricEndpointTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.exchange.controller.core.management;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.ext.web.Route;
+import io.vertx.ext.web.Router;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.TestSocketUtils;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith({ VertxExtension.class, MockitoExtension.class })
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public abstract class AbstractMetricEndpointTest {
+
+    protected static int serverPort;
+    protected static HttpServer httpServer;
+    protected static Router mainRouter;
+
+    @BeforeAll
+    public static void startServer(Vertx vertx, VertxTestContext context) {
+        final HttpServerOptions httpServerOptions = new HttpServerOptions();
+        serverPort = TestSocketUtils.findAvailableTcpPort();
+        httpServerOptions.setPort(serverPort);
+        mainRouter = Router.router(vertx);
+        httpServer = vertx.createHttpServer(httpServerOptions);
+        httpServer.requestHandler(mainRouter).listen(serverPort).andThen(context.succeedingThenComplete());
+    }
+
+    @AfterAll
+    public static void stopServer(VertxTestContext context) {
+        httpServer.close().andThen(context.succeedingThenComplete());
+    }
+
+    @AfterEach
+    public void afterEach() {
+        mainRouter.getRoutes().forEach(Route::remove);
+    }
+}

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/management/ControllerTargetIdMetricEndpointTest.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/management/ControllerTargetIdMetricEndpointTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.exchange.controller.core.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.exchange.api.batch.BatchStatus;
+import io.gravitee.exchange.api.configuration.IdentifyConfiguration;
+import io.gravitee.exchange.api.controller.ExchangeController;
+import io.gravitee.exchange.api.controller.metrics.BatchMetric;
+import io.gravitee.exchange.api.controller.metrics.ChannelMetric;
+import io.gravitee.exchange.controller.core.management.error.ManagementError;
+import io.reactivex.rxjava3.core.Flowable;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.Json;
+import io.vertx.junit5.VertxTestContext;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class ControllerTargetIdMetricEndpointTest extends AbstractMetricEndpointTest {
+
+    @Mock
+    private ExchangeController exchangeController;
+
+    private ControllerTargetIdMetricsEndpoint cut;
+
+    @BeforeEach
+    public void beforeEach() {
+        cut = new ControllerTargetIdMetricsEndpoint(new IdentifyConfiguration(new MockEnvironment()), exchangeController);
+        mainRouter.route(HttpMethod.valueOf(cut.method().name()), cut.path()).handler(cut::handle);
+    }
+
+    @Test
+    void should_return_500_on_error(Vertx vertx, VertxTestContext context) {
+        when(exchangeController.channelsMetricsForTarget(any())).thenReturn(Flowable.error(new RuntimeException()));
+
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/targets/error")
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(500);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                ManagementError managementError = Json.decodeValue(buffer, ManagementError.class);
+                assertThat(managementError.code()).isEqualTo(500);
+                assertThat(managementError.message()).isEqualTo("Unable to retrieve target metrics for the given target [error]");
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+
+    @Test
+    void should_return_404_when_id_not_found(Vertx vertx, VertxTestContext context) {
+        when(exchangeController.channelsMetricsForTarget("unknown")).thenReturn(Flowable.empty());
+        when(exchangeController.batchsMetricsForTarget("unknown")).thenReturn(Flowable.empty());
+
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/targets/unknown")
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(404);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                ManagementError managementError = Json.decodeValue(buffer, ManagementError.class);
+                assertThat(managementError.code()).isEqualTo(404);
+                assertThat(managementError.message()).isEqualTo("No metrics found for the given target [unknown]");
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+
+    @Test
+    void should_return_target_metric_for_specific_target(Vertx vertx, VertxTestContext context) {
+        ChannelMetric channelMetric = ChannelMetric.builder().id("id").active(true).pendingCommands(false).primary(true).build();
+        when(exchangeController.channelsMetricsForTarget("target")).thenReturn(Flowable.just(channelMetric));
+        BatchMetric batchMetric = BatchMetric
+            .builder()
+            .id("id1")
+            .key("key1")
+            .status(BatchStatus.SUCCEEDED)
+            .errorDetails("errorDetails")
+            .retry(1)
+            .maxRetry(2)
+            .lastRetryAt(Instant.now())
+            .build();
+        when(exchangeController.batchsMetricsForTarget("target")).thenReturn(Flowable.just(batchMetric));
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/targets/%s".formatted("target"))
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(200);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                Result result = Json.decodeValue(buffer, Result.class);
+                assertThat(result.channels()).containsOnly(channelMetric);
+                assertThat(result.batchs()).containsOnly(batchMetric);
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+
+    @Test
+    void should_return_target_metric_for_specific_target_with_batch(Vertx vertx, VertxTestContext context) {
+        ChannelMetric channelMetric = ChannelMetric.builder().id("id").active(true).pendingCommands(false).primary(true).build();
+        when(exchangeController.channelsMetricsForTarget("target")).thenReturn(Flowable.just(channelMetric));
+        when(exchangeController.batchsMetricsForTarget(any())).thenReturn(Flowable.empty());
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/targets/%s".formatted("target"))
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(200);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                Result result = Json.decodeValue(buffer, Result.class);
+                assertThat(result.channels()).containsOnly(channelMetric);
+                assertThat(result.batchs()).isEmpty();
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+
+    public record Result(List<ChannelMetric> channels, List<BatchMetric> batchs) {}
+}

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/management/ControllerTargetsMetricsEndpointTest.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/management/ControllerTargetsMetricsEndpointTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.exchange.controller.core.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.exchange.api.batch.BatchStatus;
+import io.gravitee.exchange.api.configuration.IdentifyConfiguration;
+import io.gravitee.exchange.api.controller.ExchangeController;
+import io.gravitee.exchange.api.controller.metrics.BatchMetric;
+import io.gravitee.exchange.api.controller.metrics.ChannelMetric;
+import io.gravitee.exchange.api.controller.metrics.TargetBatchsMetric;
+import io.gravitee.exchange.api.controller.metrics.TargetChannelsMetric;
+import io.gravitee.exchange.controller.core.management.error.ManagementError;
+import io.reactivex.rxjava3.core.Flowable;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.junit5.VertxTestContext;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class ControllerTargetsMetricsEndpointTest extends AbstractMetricEndpointTest {
+
+    @Mock
+    private ExchangeController exchangeController;
+
+    private ControllerTargetsMetricsEndpoint cut;
+
+    @BeforeEach
+    public void beforeEach() {
+        cut = new ControllerTargetsMetricsEndpoint(new IdentifyConfiguration(new MockEnvironment()), exchangeController);
+        mainRouter.route(HttpMethod.valueOf(cut.method().name()), cut.path()).handler(cut::handle);
+    }
+
+    @Test
+    void should_return_500_when_error_occurred_retrieving_targets_channels_metrics(Vertx vertx, VertxTestContext context) {
+        when(exchangeController.channelsMetricsByTarget()).thenReturn(Flowable.error(new RuntimeException()));
+        when(exchangeController.batchsMetricsByTarget()).thenReturn(Flowable.empty());
+
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/targets")
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(500);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                ManagementError managementError = Json.decodeValue(buffer, ManagementError.class);
+                assertThat(managementError.code()).isEqualTo(500);
+                assertThat(managementError.message()).isEqualTo("Unable to retrieve targets metrics");
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+
+    @Test
+    void should_return_500_when_error_occurred_retrieving_targets_batchs_metrics(Vertx vertx, VertxTestContext context) {
+        ChannelMetric channelMetric = ChannelMetric.builder().id("id").active(true).pendingCommands(false).primary(true).build();
+        TargetChannelsMetric targetChannelsMetric = TargetChannelsMetric.builder().id("target").channels(List.of(channelMetric)).build();
+        when(exchangeController.channelsMetricsByTarget()).thenReturn(Flowable.just(targetChannelsMetric));
+        when(exchangeController.batchsMetricsByTarget()).thenReturn(Flowable.error(new RuntimeException()));
+
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/targets")
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(500);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                ManagementError managementError = Json.decodeValue(buffer, ManagementError.class);
+                assertThat(managementError.code()).isEqualTo(500);
+                assertThat(managementError.message()).isEqualTo("Unable to retrieve targets metrics");
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+
+    @Test
+    void should_return_empty_array_when_no_metrics(Vertx vertx, VertxTestContext context) {
+        when(exchangeController.channelsMetricsByTarget()).thenReturn(Flowable.empty());
+        when(exchangeController.batchsMetricsByTarget()).thenReturn(Flowable.empty());
+
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/targets")
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(200);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                assertThat(buffer).hasToString("[ ]");
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+
+    @Test
+    void should_return_empty_array_when_no_metrics_even_with_orphan_batch(Vertx vertx, VertxTestContext context) {
+        when(exchangeController.channelsMetricsByTarget()).thenReturn(Flowable.empty());
+        BatchMetric orphanBatch = BatchMetric
+            .builder()
+            .id("id1")
+            .key("key1")
+            .status(BatchStatus.SUCCEEDED)
+            .errorDetails("errorDetails")
+            .retry(1)
+            .maxRetry(2)
+            .lastRetryAt(Instant.now())
+            .build();
+        when(exchangeController.batchsMetricsByTarget())
+            .thenReturn(Flowable.just(TargetBatchsMetric.builder().id("orphan").batchs(List.of(orphanBatch)).build()));
+
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/targets")
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(200);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                assertThat(buffer).hasToString("[ ]");
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+
+    @Test
+    void should_return_target_metrics(Vertx vertx, VertxTestContext context) {
+        ChannelMetric channelMetric1 = ChannelMetric.builder().id("id").active(true).pendingCommands(false).primary(true).build();
+        TargetChannelsMetric targetChannelsMetric1 = TargetChannelsMetric.builder().id("target").channels(List.of(channelMetric1)).build();
+        ChannelMetric channelMetric2 = ChannelMetric.builder().id("id2").active(true).pendingCommands(false).primary(true).build();
+        TargetChannelsMetric targetChannelsMetric2 = TargetChannelsMetric.builder().id("target2").channels(List.of(channelMetric2)).build();
+        when(exchangeController.channelsMetricsByTarget()).thenReturn(Flowable.just(targetChannelsMetric1, targetChannelsMetric2));
+        BatchMetric batchMetric1 = BatchMetric
+            .builder()
+            .id("id1")
+            .key("key1")
+            .status(BatchStatus.SUCCEEDED)
+            .errorDetails("errorDetails")
+            .retry(1)
+            .maxRetry(2)
+            .lastRetryAt(Instant.now())
+            .build();
+        BatchMetric batchMetric2 = BatchMetric
+            .builder()
+            .id("id2")
+            .key("key2")
+            .status(BatchStatus.PENDING)
+            .errorDetails("errorDetails-pending")
+            .retry(5)
+            .maxRetry(10)
+            .lastRetryAt(Instant.now())
+            .build();
+        when(exchangeController.batchsMetricsByTarget())
+            .thenReturn(
+                Flowable.just(
+                    TargetBatchsMetric.builder().id("target").batchs(List.of(batchMetric1)).build(),
+                    TargetBatchsMetric.builder().id("target2").batchs(List.of(batchMetric2)).build()
+                )
+            );
+
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/targets")
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(200);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                JsonArray jsonArray = (JsonArray) Json.decodeValue(buffer);
+                assertThat(jsonArray).hasSize(2);
+                Result result1 = jsonArray.getJsonObject(0).mapTo(Result.class);
+                assertThat(result1.id()).isEqualTo("target");
+                assertThat(result1.channels()).containsOnly(channelMetric1);
+                assertThat(result1.batchs()).containsOnly(batchMetric1);
+                Result result2 = jsonArray.getJsonObject(1).mapTo(Result.class);
+                assertThat(result2.id()).isEqualTo("target2");
+                assertThat(result2.channels()).containsOnly(channelMetric2);
+                assertThat(result2.batchs()).containsOnly(batchMetric2);
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+
+    public record Result(String id, List<ChannelMetric> channels, List<BatchMetric> batchs) {}
+}

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/management/batch/ControllerBatchMetricsEndpointTest.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/management/batch/ControllerBatchMetricsEndpointTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.exchange.controller.core.management.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.exchange.api.batch.BatchStatus;
+import io.gravitee.exchange.api.configuration.IdentifyConfiguration;
+import io.gravitee.exchange.api.controller.ExchangeController;
+import io.gravitee.exchange.api.controller.metrics.BatchMetric;
+import io.gravitee.exchange.controller.core.management.AbstractMetricEndpointTest;
+import io.gravitee.exchange.controller.core.management.error.ManagementError;
+import io.reactivex.rxjava3.core.Maybe;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.Json;
+import io.vertx.junit5.VertxTestContext;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class ControllerBatchMetricsEndpointTest extends AbstractMetricEndpointTest {
+
+    @Mock
+    private ExchangeController exchangeController;
+
+    private ControllerBatchMetricsEndpoint cut;
+
+    @BeforeEach
+    public void beforeEach() {
+        cut = new ControllerBatchMetricsEndpoint(new IdentifyConfiguration(new MockEnvironment()), exchangeController);
+        mainRouter.route(HttpMethod.valueOf(cut.method().name()), cut.path()).handler(cut::handle);
+    }
+
+    @Test
+    void should_return_500_on_error(Vertx vertx, VertxTestContext context) {
+        when(exchangeController.batchMetric(any())).thenReturn(Maybe.error(new RuntimeException()));
+
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/batchs/error")
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(500);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                ManagementError managementError = Json.decodeValue(buffer, ManagementError.class);
+                assertThat(managementError.code()).isEqualTo(500);
+                assertThat(managementError.message()).isEqualTo("Unable to retrieve batch metrics for the given id [error]");
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+
+    @Test
+    void should_return_404_when_id_not_found(Vertx vertx, VertxTestContext context) {
+        when(exchangeController.batchMetric("unknown")).thenReturn(Maybe.empty());
+
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/batchs/unknown")
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(404);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                ManagementError managementError = Json.decodeValue(buffer, ManagementError.class);
+                assertThat(managementError.code()).isEqualTo(404);
+                assertThat(managementError.message()).isEqualTo("No batch found for the given id [unknown]");
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+
+    @Test
+    void should_return_batch_metric(Vertx vertx, VertxTestContext context) {
+        BatchMetric batch = BatchMetric
+            .builder()
+            .id("id")
+            .key("key")
+            .targetId("targetId")
+            .status(BatchStatus.PENDING)
+            .errorDetails("errorDetails")
+            .retry(1)
+            .maxRetry(2)
+            .lastRetryAt(Instant.now())
+            .build();
+        when(exchangeController.batchMetric(batch.id())).thenReturn(Maybe.just(batch));
+
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/batchs/%s".formatted(batch.id()))
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(200);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                BatchMetric batchMetric = Json.decodeValue(buffer, BatchMetric.class);
+                assertThat(batchMetric.id()).isEqualTo(batch.id());
+                assertThat(batchMetric.key()).isEqualTo(batch.key());
+                assertThat(batchMetric.status()).isEqualTo(batch.status());
+                assertThat(batchMetric.retry()).isEqualTo(batch.retry());
+                assertThat(batchMetric.maxRetry()).isEqualTo(batch.maxRetry());
+                assertThat(batchMetric.lastRetryAt()).isEqualTo(batch.lastRetryAt());
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+}

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/management/batch/ControllerBatchsMetricsEndpointTest.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/management/batch/ControllerBatchsMetricsEndpointTest.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.exchange.controller.core.management.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.exchange.api.batch.BatchStatus;
+import io.gravitee.exchange.api.configuration.IdentifyConfiguration;
+import io.gravitee.exchange.api.controller.ExchangeController;
+import io.gravitee.exchange.api.controller.metrics.BatchMetric;
+import io.gravitee.exchange.api.controller.metrics.TargetBatchsMetric;
+import io.gravitee.exchange.controller.core.management.AbstractMetricEndpointTest;
+import io.gravitee.exchange.controller.core.management.error.ManagementError;
+import io.reactivex.rxjava3.core.Flowable;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.junit5.VertxTestContext;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class ControllerBatchsMetricsEndpointTest extends AbstractMetricEndpointTest {
+
+    @Mock
+    private ExchangeController exchangeController;
+
+    private ControllerBatchsMetricsEndpoint cut;
+
+    @BeforeEach
+    public void beforeEach() {
+        cut = new ControllerBatchsMetricsEndpoint(new IdentifyConfiguration(new MockEnvironment()), exchangeController);
+        mainRouter.route(HttpMethod.valueOf(cut.method().name()), cut.path()).handler(cut::handle);
+    }
+
+    @Test
+    void should_return_500_on_error(Vertx vertx, VertxTestContext context) {
+        when(exchangeController.batchsMetricsByTarget()).thenReturn(Flowable.error(new RuntimeException()));
+
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/batchs")
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(500);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                ManagementError managementError = Json.decodeValue(buffer, ManagementError.class);
+                assertThat(managementError.code()).isEqualTo(500);
+                assertThat(managementError.message()).isEqualTo("Unable to retrieve batchs metrics");
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+
+    @Test
+    void should_return_empty_array_when_no_batchs_found(Vertx vertx, VertxTestContext context) {
+        when(exchangeController.batchsMetricsByTarget()).thenReturn(Flowable.empty());
+
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/batchs")
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(200);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                assertThat(buffer).hasToString("[ ]");
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+
+    @Test
+    void should_return_batchs_metric(Vertx vertx, VertxTestContext context) {
+        BatchMetric batchMetric1 = BatchMetric
+            .builder()
+            .id("id1")
+            .key("key1")
+            .targetId("target")
+            .status(BatchStatus.SUCCEEDED)
+            .errorDetails("errorDetails")
+            .retry(1)
+            .maxRetry(2)
+            .lastRetryAt(Instant.now())
+            .build();
+        BatchMetric batchMetric2 = BatchMetric
+            .builder()
+            .id("id2")
+            .key("key2")
+            .targetId("target2")
+            .status(BatchStatus.PENDING)
+            .errorDetails("errorDetails-pending")
+            .retry(5)
+            .maxRetry(10)
+            .lastRetryAt(Instant.now())
+            .build();
+        when(exchangeController.batchsMetricsByTarget())
+            .thenReturn(
+                Flowable.just(
+                    TargetBatchsMetric.builder().id("target").batchs(List.of(batchMetric1)).build(),
+                    TargetBatchsMetric.builder().id("target2").batchs(List.of(batchMetric2)).build()
+                )
+            );
+
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/batchs")
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(200);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                JsonArray jsonArray = (JsonArray) Json.decodeValue(buffer);
+                assertThat(jsonArray).hasSize(2);
+                BatchMetric result1 = jsonArray.getJsonObject(0).mapTo(BatchMetric.class);
+                assertThat(result1.id()).isEqualTo(result1.id());
+                assertThat(result1.key()).isEqualTo(result1.key());
+                assertThat(result1.targetId()).isEqualTo("target");
+                assertThat(result1.retry()).isEqualTo(result1.retry());
+                assertThat(result1.maxRetry()).isEqualTo(result1.maxRetry());
+                assertThat(result1.lastRetryAt()).isEqualTo(result1.lastRetryAt());
+                assertThat(result1.errorDetails()).isEqualTo(result1.errorDetails());
+                BatchMetric result2 = jsonArray.getJsonObject(1).mapTo(BatchMetric.class);
+                assertThat(result2.id()).isEqualTo(result2.id());
+                assertThat(result2.key()).isEqualTo(result2.key());
+                assertThat(result2.targetId()).isEqualTo("target2");
+                assertThat(result2.retry()).isEqualTo(result2.retry());
+                assertThat(result2.maxRetry()).isEqualTo(result2.maxRetry());
+                assertThat(result2.lastRetryAt()).isEqualTo(result2.lastRetryAt());
+                assertThat(result2.errorDetails()).isEqualTo(result2.errorDetails());
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+
+    @Test
+    void should_return_filtered_batchs_metric_with_status_filtering(Vertx vertx, VertxTestContext context) {
+        BatchMetric batchSucceeded = BatchMetric
+            .builder()
+            .id("id-succeeded")
+            .key("key-succeeded")
+            .targetId("target")
+            .status(BatchStatus.SUCCEEDED)
+            .errorDetails("errorDetails-succeeded")
+            .retry(1)
+            .maxRetry(2)
+            .lastRetryAt(Instant.now())
+            .build();
+        BatchMetric batchPending = BatchMetric
+            .builder()
+            .id("id-pending")
+            .key("key-pending")
+            .targetId("target2")
+            .status(BatchStatus.PENDING)
+            .errorDetails("errorDetails-pending")
+            .retry(5)
+            .maxRetry(10)
+            .lastRetryAt(Instant.now())
+            .build();
+        when(exchangeController.batchsMetricsByTarget())
+            .thenReturn(
+                Flowable.just(
+                    TargetBatchsMetric.builder().id("target").batchs(List.of(batchSucceeded)).build(),
+                    TargetBatchsMetric.builder().id("target2").batchs(List.of(batchPending)).build()
+                )
+            );
+
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/batchs?status=PENDING")
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(200);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                JsonArray jsonArray = (JsonArray) Json.decodeValue(buffer);
+                assertThat(jsonArray).hasSize(1);
+                BatchMetric batchMetric = jsonArray.getJsonObject(0).mapTo(BatchMetric.class);
+                assertThat(batchMetric.id()).isEqualTo(batchPending.id());
+                assertThat(batchMetric.key()).isEqualTo(batchPending.key());
+                assertThat(batchMetric.targetId()).isEqualTo(batchPending.targetId());
+                assertThat(batchMetric.status()).isEqualTo(batchPending.status());
+                assertThat(batchMetric.retry()).isEqualTo(batchPending.retry());
+                assertThat(batchMetric.maxRetry()).isEqualTo(batchPending.maxRetry());
+                assertThat(batchMetric.lastRetryAt()).isEqualTo(batchPending.lastRetryAt());
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+
+    @Test
+    void should_return_filtered_batchs_metric_with_target_filtering(Vertx vertx, VertxTestContext context) {
+        BatchMetric batchSucceeded = BatchMetric
+            .builder()
+            .id("id-succeeded")
+            .key("key-succeeded")
+            .targetId("targetId-succeeded")
+            .status(BatchStatus.SUCCEEDED)
+            .errorDetails("errorDetails-succeeded")
+            .retry(1)
+            .maxRetry(2)
+            .lastRetryAt(Instant.now())
+            .build();
+        BatchMetric batchPending = BatchMetric
+            .builder()
+            .id("id-pending")
+            .key("key-pending")
+            .targetId("targetId-pending")
+            .status(BatchStatus.PENDING)
+            .errorDetails("errorDetails-pending")
+            .retry(5)
+            .maxRetry(10)
+            .lastRetryAt(Instant.now())
+            .build();
+        when(exchangeController.batchsMetricsByTarget())
+            .thenReturn(
+                Flowable.just(
+                    TargetBatchsMetric.builder().id("targetId-succeeded").batchs(List.of(batchSucceeded)).build(),
+                    TargetBatchsMetric.builder().id("targetId-pending").batchs(List.of(batchPending)).build()
+                )
+            );
+
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/batchs?targetId=targetId-pending")
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(200);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                JsonArray jsonArray = (JsonArray) Json.decodeValue(buffer);
+                assertThat(jsonArray).hasSize(1);
+                BatchMetric batchMetric = jsonArray.getJsonObject(0).mapTo(BatchMetric.class);
+                assertThat(batchMetric.id()).isEqualTo(batchPending.id());
+                assertThat(batchMetric.key()).isEqualTo(batchPending.key());
+                assertThat(batchMetric.targetId()).isEqualTo(batchPending.targetId());
+                assertThat(batchMetric.status()).isEqualTo(batchPending.status());
+                assertThat(batchMetric.retry()).isEqualTo(batchPending.retry());
+                assertThat(batchMetric.maxRetry()).isEqualTo(batchPending.maxRetry());
+                assertThat(batchMetric.lastRetryAt()).isEqualTo(batchPending.lastRetryAt());
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+}

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/management/batch/ControllerTargetBatchMetricsEndpointTest.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/management/batch/ControllerTargetBatchMetricsEndpointTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.exchange.controller.core.management.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.exchange.api.batch.BatchStatus;
+import io.gravitee.exchange.api.configuration.IdentifyConfiguration;
+import io.gravitee.exchange.api.controller.ExchangeController;
+import io.gravitee.exchange.api.controller.metrics.BatchMetric;
+import io.gravitee.exchange.controller.core.management.AbstractMetricEndpointTest;
+import io.gravitee.exchange.controller.core.management.error.ManagementError;
+import io.reactivex.rxjava3.core.Flowable;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.junit5.VertxTestContext;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class ControllerTargetBatchMetricsEndpointTest extends AbstractMetricEndpointTest {
+
+    @Mock
+    private ExchangeController exchangeController;
+
+    private ControllerTargetIdBatchsMetricsEndpoint cut;
+
+    @BeforeEach
+    public void beforeEach() {
+        cut = new ControllerTargetIdBatchsMetricsEndpoint(new IdentifyConfiguration(new MockEnvironment()), exchangeController);
+        mainRouter.route(HttpMethod.valueOf(cut.method().name()), cut.path()).handler(cut::handle);
+    }
+
+    @Test
+    void should_return_500_on_error(Vertx vertx, VertxTestContext context) {
+        when(exchangeController.batchsMetricsForTarget(any())).thenReturn(Flowable.error(new RuntimeException()));
+
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/targets/error/batchs")
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(500);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                ManagementError managementError = Json.decodeValue(buffer, ManagementError.class);
+                assertThat(managementError.code()).isEqualTo(500);
+                assertThat(managementError.message()).isEqualTo("Unable to retrieve batchs metrics for the given target [error]");
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+
+    @Test
+    void should_return_empty_array_when_no_batchs_found(Vertx vertx, VertxTestContext context) {
+        when(exchangeController.batchsMetricsForTarget("unknown")).thenReturn(Flowable.empty());
+
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/targets/unknown/batchs")
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(200);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                assertThat(buffer).hasToString("[ ]");
+
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+
+    @Test
+    void should_return_batch_metric_for_target(Vertx vertx, VertxTestContext context) {
+        BatchMetric batch = BatchMetric
+            .builder()
+            .id("id")
+            .key("key")
+            .targetId("targetId")
+            .status(BatchStatus.PENDING)
+            .errorDetails("errorDetails")
+            .retry(1)
+            .maxRetry(2)
+            .lastRetryAt(Instant.now())
+            .build();
+        when(exchangeController.batchsMetricsForTarget(batch.targetId())).thenReturn(Flowable.just(batch));
+
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/targets/%s/batchs".formatted(batch.targetId()))
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(200);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                JsonArray jsonArray = (JsonArray) Json.decodeValue(buffer);
+                assertThat(jsonArray).hasSize(1);
+                BatchMetric batchMetric = jsonArray.getJsonObject(0).mapTo(BatchMetric.class);
+                assertThat(batchMetric.id()).isEqualTo(batch.id());
+                assertThat(batchMetric.key()).isEqualTo(batch.key());
+                assertThat(batchMetric.status()).isEqualTo(batch.status());
+                assertThat(batchMetric.retry()).isEqualTo(batch.retry());
+                assertThat(batchMetric.maxRetry()).isEqualTo(batch.maxRetry());
+                assertThat(batchMetric.lastRetryAt()).isEqualTo(batch.lastRetryAt());
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+}

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/management/channels/ControllerChannelMetricsEndpointTest.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/management/channels/ControllerChannelMetricsEndpointTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.exchange.controller.core.management.channels;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.exchange.api.batch.BatchStatus;
+import io.gravitee.exchange.api.configuration.IdentifyConfiguration;
+import io.gravitee.exchange.api.controller.ExchangeController;
+import io.gravitee.exchange.api.controller.metrics.BatchMetric;
+import io.gravitee.exchange.api.controller.metrics.ChannelMetric;
+import io.gravitee.exchange.controller.core.management.AbstractMetricEndpointTest;
+import io.gravitee.exchange.controller.core.management.batch.ControllerBatchMetricsEndpoint;
+import io.gravitee.exchange.controller.core.management.channel.ControllerChannelMetricsEndpoint;
+import io.gravitee.exchange.controller.core.management.error.ManagementError;
+import io.reactivex.rxjava3.core.Maybe;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.Json;
+import io.vertx.junit5.VertxTestContext;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class ControllerChannelMetricsEndpointTest extends AbstractMetricEndpointTest {
+
+    @Mock
+    private ExchangeController exchangeController;
+
+    private ControllerChannelMetricsEndpoint cut;
+
+    @BeforeEach
+    public void beforeEach() {
+        cut = new ControllerChannelMetricsEndpoint(new IdentifyConfiguration(new MockEnvironment()), exchangeController);
+        mainRouter.route(HttpMethod.valueOf(cut.method().name()), cut.path()).handler(cut::handle);
+    }
+
+    @Test
+    void should_return_500_on_error(Vertx vertx, VertxTestContext context) {
+        when(exchangeController.channelMetric(any())).thenReturn(Maybe.error(new RuntimeException()));
+
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/channels/error")
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(500);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                ManagementError managementError = Json.decodeValue(buffer, ManagementError.class);
+                assertThat(managementError.code()).isEqualTo(500);
+                assertThat(managementError.message()).isEqualTo("Unable to retrieve channel metrics for the given id [error]");
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+
+    @Test
+    void should_return_404_when_id_not_found(Vertx vertx, VertxTestContext context) {
+        when(exchangeController.channelMetric("unknown")).thenReturn(Maybe.empty());
+
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/channels/unknown")
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(404);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                ManagementError managementError = Json.decodeValue(buffer, ManagementError.class);
+                assertThat(managementError.code()).isEqualTo(404);
+                assertThat(managementError.message()).isEqualTo("No channel found for the given id [unknown]");
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+
+    @Test
+    void should_return_batch_metric(Vertx vertx, VertxTestContext context) {
+        ChannelMetric channelMetric = ChannelMetric
+            .builder()
+            .id("id1")
+            .targetId("target1")
+            .active(true)
+            .pendingCommands(false)
+            .primary(true)
+            .build();
+
+        when(exchangeController.channelMetric(channelMetric.id())).thenReturn(Maybe.just(channelMetric));
+
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/channels/%s".formatted(channelMetric.id()))
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(200);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                ChannelMetric returnChannelMetric = Json.decodeValue(buffer, ChannelMetric.class);
+                assertThat(returnChannelMetric.id()).isEqualTo(channelMetric.id());
+                assertThat(returnChannelMetric.targetId()).isEqualTo(channelMetric.targetId());
+                assertThat(returnChannelMetric.active()).isEqualTo(channelMetric.active());
+                assertThat(returnChannelMetric.pendingCommands()).isEqualTo(channelMetric.pendingCommands());
+                assertThat(returnChannelMetric.primary()).isEqualTo(channelMetric.primary());
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+}

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/management/channels/ControllerChannelsMetricEndpointTest.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/management/channels/ControllerChannelsMetricEndpointTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.exchange.controller.core.management.channels;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.exchange.api.batch.BatchStatus;
+import io.gravitee.exchange.api.configuration.IdentifyConfiguration;
+import io.gravitee.exchange.api.controller.ExchangeController;
+import io.gravitee.exchange.api.controller.metrics.BatchMetric;
+import io.gravitee.exchange.api.controller.metrics.ChannelMetric;
+import io.gravitee.exchange.api.controller.metrics.TargetBatchsMetric;
+import io.gravitee.exchange.api.controller.metrics.TargetChannelsMetric;
+import io.gravitee.exchange.controller.core.management.AbstractMetricEndpointTest;
+import io.gravitee.exchange.controller.core.management.channel.ControllerChannelsMetricsEndpoint;
+import io.gravitee.exchange.controller.core.management.channel.ControllerTargetIdChannelsMetricsEndpoint;
+import io.gravitee.exchange.controller.core.management.error.ManagementError;
+import io.reactivex.rxjava3.core.Flowable;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.junit5.VertxTestContext;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class ControllerChannelsMetricEndpointTest extends AbstractMetricEndpointTest {
+
+    @Mock
+    private ExchangeController exchangeController;
+
+    private ControllerChannelsMetricsEndpoint cut;
+
+    @BeforeEach
+    public void beforeEach() {
+        cut = new ControllerChannelsMetricsEndpoint(new IdentifyConfiguration(new MockEnvironment()), exchangeController);
+        mainRouter.route(HttpMethod.valueOf(cut.method().name()), cut.path()).handler(cut::handle);
+    }
+
+    @Test
+    void should_return_500_on_error(Vertx vertx, VertxTestContext context) {
+        when(exchangeController.channelsMetricsByTarget()).thenReturn(Flowable.error(new RuntimeException()));
+
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/channels")
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(500);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                ManagementError managementError = Json.decodeValue(buffer, ManagementError.class);
+                assertThat(managementError.code()).isEqualTo(500);
+                assertThat(managementError.message()).isEqualTo("Unable to retrieve channels metrics");
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+
+    @Test
+    void should_return_empty_array_when_no_channels_found(Vertx vertx, VertxTestContext context) {
+        when(exchangeController.channelsMetricsByTarget()).thenReturn(Flowable.empty());
+
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/channels")
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(200);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                assertThat(buffer).hasToString("[ ]");
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+
+    @Test
+    void should_return_channels_metrics(Vertx vertx, VertxTestContext context) {
+        ChannelMetric channelMetric = ChannelMetric
+            .builder()
+            .id("id")
+            .targetId("target")
+            .active(true)
+            .pendingCommands(false)
+            .primary(true)
+            .build();
+        when(exchangeController.channelsMetricsByTarget())
+            .thenReturn(Flowable.just(TargetChannelsMetric.builder().id("target").channels(List.of(channelMetric)).build()));
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/channels")
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(200);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                JsonArray jsonArray = (JsonArray) Json.decodeValue(buffer);
+                assertThat(jsonArray).hasSize(1);
+                ChannelMetric channelMetricReturned = jsonArray.getJsonObject(0).mapTo(ChannelMetric.class);
+                assertThat(channelMetricReturned.id()).isEqualTo(channelMetric.id());
+                assertThat(channelMetricReturned.targetId()).isEqualTo(channelMetric.targetId());
+                assertThat(channelMetricReturned.active()).isEqualTo(channelMetric.active());
+                assertThat(channelMetricReturned.pendingCommands()).isEqualTo(channelMetric.pendingCommands());
+                assertThat(channelMetricReturned.primary()).isEqualTo(channelMetric.primary());
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+
+    @Test
+    void should_return_filtered_channels_metrics_with_active_filtering(Vertx vertx, VertxTestContext context) {
+        ChannelMetric activeChannelMetric = ChannelMetric
+            .builder()
+            .id("id1")
+            .targetId("target1")
+            .active(true)
+            .pendingCommands(false)
+            .primary(true)
+            .build();
+        ChannelMetric inactiveChannelMetric = ChannelMetric
+            .builder()
+            .id("id2")
+            .targetId("target2")
+            .active(false)
+            .pendingCommands(false)
+            .primary(true)
+            .build();
+
+        when(exchangeController.channelsMetricsByTarget())
+            .thenReturn(
+                Flowable.just(
+                    TargetChannelsMetric.builder().id(activeChannelMetric.targetId()).channels(List.of(activeChannelMetric)).build(),
+                    TargetChannelsMetric.builder().id(inactiveChannelMetric.targetId()).channels(List.of(inactiveChannelMetric)).build()
+                )
+            );
+
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/channels?active=true")
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(200);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                JsonArray jsonArray = (JsonArray) Json.decodeValue(buffer);
+                assertThat(jsonArray).hasSize(1);
+                ChannelMetric channelMetricReturned = jsonArray.getJsonObject(0).mapTo(ChannelMetric.class);
+                assertThat(channelMetricReturned.id()).isEqualTo(activeChannelMetric.id());
+                assertThat(channelMetricReturned.targetId()).isEqualTo(activeChannelMetric.targetId());
+                assertThat(channelMetricReturned.active()).isEqualTo(activeChannelMetric.active());
+                assertThat(channelMetricReturned.pendingCommands()).isEqualTo(activeChannelMetric.pendingCommands());
+                assertThat(channelMetricReturned.primary()).isEqualTo(activeChannelMetric.primary());
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+
+    @Test
+    void should_return_filtered_channels_metrics_with_target_filtering(Vertx vertx, VertxTestContext context) {
+        ChannelMetric activeChannelMetric = ChannelMetric
+            .builder()
+            .id("id1")
+            .targetId("target1")
+            .active(true)
+            .pendingCommands(false)
+            .primary(true)
+            .build();
+        ChannelMetric inactiveChannelMetric = ChannelMetric
+            .builder()
+            .id("id2")
+            .targetId("target2")
+            .active(false)
+            .pendingCommands(false)
+            .primary(true)
+            .build();
+
+        when(exchangeController.channelsMetricsByTarget())
+            .thenReturn(
+                Flowable.just(
+                    TargetChannelsMetric.builder().id(activeChannelMetric.targetId()).channels(List.of(activeChannelMetric)).build(),
+                    TargetChannelsMetric.builder().id(inactiveChannelMetric.targetId()).channels(List.of(inactiveChannelMetric)).build()
+                )
+            );
+
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/channels?targetId=target1")
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(200);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                JsonArray jsonArray = (JsonArray) Json.decodeValue(buffer);
+                assertThat(jsonArray).hasSize(1);
+                ChannelMetric channelMetricReturned = jsonArray.getJsonObject(0).mapTo(ChannelMetric.class);
+                assertThat(channelMetricReturned.id()).isEqualTo(activeChannelMetric.id());
+                assertThat(channelMetricReturned.targetId()).isEqualTo(activeChannelMetric.targetId());
+                assertThat(channelMetricReturned.active()).isEqualTo(activeChannelMetric.active());
+                assertThat(channelMetricReturned.pendingCommands()).isEqualTo(activeChannelMetric.pendingCommands());
+                assertThat(channelMetricReturned.primary()).isEqualTo(activeChannelMetric.primary());
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+}

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/management/channels/ControllerTargetChannelsMetricEndpointTest.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/management/channels/ControllerTargetChannelsMetricEndpointTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.exchange.controller.core.management.channels;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.exchange.api.configuration.IdentifyConfiguration;
+import io.gravitee.exchange.api.controller.ExchangeController;
+import io.gravitee.exchange.api.controller.metrics.ChannelMetric;
+import io.gravitee.exchange.controller.core.management.AbstractMetricEndpointTest;
+import io.gravitee.exchange.controller.core.management.channel.ControllerTargetIdChannelsMetricsEndpoint;
+import io.gravitee.exchange.controller.core.management.error.ManagementError;
+import io.reactivex.rxjava3.core.Flowable;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class ControllerTargetChannelsMetricEndpointTest extends AbstractMetricEndpointTest {
+
+    @Mock
+    private ExchangeController exchangeController;
+
+    private ControllerTargetIdChannelsMetricsEndpoint cut;
+
+    @BeforeEach
+    public void beforeEach() {
+        cut = new ControllerTargetIdChannelsMetricsEndpoint(new IdentifyConfiguration(new MockEnvironment()), exchangeController);
+        mainRouter.route(HttpMethod.valueOf(cut.method().name()), cut.path()).handler(cut::handle);
+    }
+
+    @Test
+    void should_return_500_on_error(Vertx vertx, VertxTestContext context) {
+        when(exchangeController.channelsMetricsForTarget("error")).thenReturn(Flowable.error(new RuntimeException()));
+
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/targets/error/channels")
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(500);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                ManagementError managementError = Json.decodeValue(buffer, ManagementError.class);
+                assertThat(managementError.code()).isEqualTo(500);
+                assertThat(managementError.message()).isEqualTo("Unable to retrieve channels metrics for the given target id [error]");
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+
+    @Test
+    void should_return_empty_array_when_no_channels_found(Vertx vertx, VertxTestContext context) {
+        when(exchangeController.channelsMetricsForTarget("unknown")).thenReturn(Flowable.empty());
+
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/targets/unknown/channels")
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(200);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                assertThat(buffer).hasToString("[ ]");
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+
+    @Test
+    void should_return_channels_metric(Vertx vertx, VertxTestContext context) {
+        ChannelMetric channelMetric = ChannelMetric
+            .builder()
+            .id("id")
+            .targetId("target")
+            .active(true)
+            .pendingCommands(false)
+            .primary(true)
+            .build();
+        when(exchangeController.channelsMetricsForTarget(channelMetric.targetId())).thenReturn(Flowable.just(channelMetric));
+
+        HttpClient httpClient = vertx.createHttpClient();
+        httpClient
+            .request(HttpMethod.GET, serverPort, "localhost", "/exchange/targets/%s/channels".formatted(channelMetric.targetId()))
+            .flatMap(HttpClientRequest::send)
+            .flatMap(httpClientResponse -> {
+                assertThat(httpClientResponse.statusCode()).isEqualTo(200);
+                return httpClientResponse.body();
+            })
+            .map(buffer -> {
+                JsonArray jsonArray = (JsonArray) Json.decodeValue(buffer);
+                assertThat(jsonArray).hasSize(1);
+                ChannelMetric channelMetricReturned = jsonArray.getJsonObject(0).mapTo(ChannelMetric.class);
+                assertThat(channelMetricReturned.id()).isEqualTo(channelMetric.id());
+                assertThat(channelMetricReturned.targetId()).isEqualTo(channelMetric.targetId());
+                assertThat(channelMetricReturned.active()).isEqualTo(channelMetric.active());
+                assertThat(channelMetricReturned.pendingCommands()).isEqualTo(channelMetric.pendingCommands());
+                assertThat(channelMetricReturned.primary()).isEqualTo(channelMetric.primary());
+                return true;
+            })
+            .onFailure(context::failNow)
+            .andThen(context.succeedingThenComplete());
+    }
+}

--- a/gravitee-exchange-controller/gravitee-exchange-controller-websocket/pom.xml
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-websocket/pom.xml
@@ -52,6 +52,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-management</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>provided</scope>

--- a/gravitee-exchange-controller/gravitee-exchange-controller-websocket/src/main/java/io/gravitee/exchange/controller/websocket/WebSocketExchangeController.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-websocket/src/main/java/io/gravitee/exchange/controller/websocket/WebSocketExchangeController.java
@@ -20,8 +20,6 @@ import io.gravitee.exchange.api.controller.ControllerCommandHandlersFactory;
 import io.gravitee.exchange.api.controller.ExchangeController;
 import io.gravitee.exchange.api.websocket.command.ExchangeSerDe;
 import io.gravitee.exchange.controller.core.DefaultExchangeController;
-import io.gravitee.exchange.controller.core.channel.primary.PrimaryChannelManager;
-import io.gravitee.exchange.controller.core.cluster.ControllerClusterManager;
 import io.gravitee.exchange.controller.websocket.auth.WebSocketControllerAuthentication;
 import io.gravitee.exchange.controller.websocket.server.WebSocketControllerServerConfiguration;
 import io.gravitee.exchange.controller.websocket.server.WebSocketControllerServerVerticle;
@@ -30,6 +28,7 @@ import io.gravitee.node.api.certificate.KeyStoreLoaderFactoryRegistry;
 import io.gravitee.node.api.certificate.KeyStoreLoaderOptions;
 import io.gravitee.node.api.certificate.TrustStoreLoaderOptions;
 import io.gravitee.node.api.cluster.ClusterManager;
+import io.gravitee.node.management.http.endpoint.ManagementEndpointManager;
 import io.gravitee.node.vertx.server.http.VertxHttpServer;
 import io.gravitee.node.vertx.server.http.VertxHttpServerFactory;
 import io.gravitee.node.vertx.server.http.VertxHttpServerOptions;
@@ -70,7 +69,33 @@ public class WebSocketExchangeController extends DefaultExchangeController imple
         final ControllerCommandHandlersFactory controllerCommandHandlersFactory,
         final ExchangeSerDe exchangeSerDe
     ) {
-        super(identifyConfiguration, clusterManager, cacheManager);
+        this(
+            identifyConfiguration,
+            clusterManager,
+            cacheManager,
+            null,
+            vertx,
+            keyStoreLoaderFactoryRegistry,
+            trustStoreLoaderFactoryRegistry,
+            controllerAuthentication,
+            controllerCommandHandlersFactory,
+            exchangeSerDe
+        );
+    }
+
+    public WebSocketExchangeController(
+        final IdentifyConfiguration identifyConfiguration,
+        final ClusterManager clusterManager,
+        final CacheManager cacheManager,
+        final ManagementEndpointManager managementEndpointManager,
+        final Vertx vertx,
+        final KeyStoreLoaderFactoryRegistry<KeyStoreLoaderOptions> keyStoreLoaderFactoryRegistry,
+        final KeyStoreLoaderFactoryRegistry<TrustStoreLoaderOptions> trustStoreLoaderFactoryRegistry,
+        final WebSocketControllerAuthentication<?> controllerAuthentication,
+        final ControllerCommandHandlersFactory controllerCommandHandlersFactory,
+        final ExchangeSerDe exchangeSerDe
+    ) {
+        super(identifyConfiguration, clusterManager, cacheManager, managementEndpointManager);
         this.vertx = vertx;
         this.serverConfiguration = new WebSocketControllerServerConfiguration(identifyConfiguration);
         this.keyStoreLoaderFactoryRegistry = keyStoreLoaderFactoryRegistry;

--- a/gravitee-exchange-controller/gravitee-exchange-controller-websocket/src/test/java/io/gravitee/exchange/controller/websocket/auth/DefaultWebSocketControllerAuthenticationTest.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-websocket/src/test/java/io/gravitee/exchange/controller/websocket/auth/DefaultWebSocketControllerAuthenticationTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 class DefaultWebSocketControllerAuthenticationTest {
 
     @Test
-    void should_return_a_valid_context__by_default() {
+    void should_return_a_valid_context_by_default() {
         DefaultWebSocketControllerAuthentication cut = new DefaultWebSocketControllerAuthentication();
         ControllerCommandContext controllerContext = cut.authenticate(null);
         assertThat(controllerContext).isInstanceOf(DefaultCommandContext.class);

--- a/pom.xml
+++ b/pom.xml
@@ -184,18 +184,6 @@
                 <artifactId>maven-source-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${maven-javadoc-plugin.version}</version>
-                <configuration>
-                    <additionalOptions>-Xdoclint:none</additionalOptions>
-                    <additionalJOption>-Xdoclint:none</additionalJOption>
-                    <quiet>true</quiet>
-                    <doclint>none</doclint>
-                    <source>${jdk.version}</source>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>com.hubspot.maven.plugins</groupId>
                 <artifactId>prettier-maven-plugin</artifactId>
                 <configuration>


### PR DESCRIPTION
**Description**

   - 8 endpoints have been added
   `/exchange/[identifier]/targets`: return metrics information on channels and batchs grouped by target. Can be filtered by status
- `/exchange/[identifier]/targets/:id`: return metrics information on channels and batchs for the given target.
- `/exchange/[identifier]/targets/:id/channels`: return metrics information on channels for the given target.
- `/exchange/[identifier]/targets/:id/batchs`: return metrics information on batchs for the given target.
- `/exchange/[identifier]/batchs`: return metrics information on batchs. Can be filtered by `status` and `targetId`;
- `/exchange/[identifier]/batchs/:id`: return metrics information for the given batch
- `/exchange/[identifier]/channels`: list channels. Can be filtered by `active` status and `targetId`;
- `/exchange/[identifier]/channels/:id`: return metrics information for the given channe


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.7.0-archi-389-add-metrics-endpoint-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/exchange/gravitee-exchange/1.7.0-archi-389-add-metrics-endpoint-SNAPSHOT/gravitee-exchange-1.7.0-archi-389-add-metrics-endpoint-SNAPSHOT.zip)
  <!-- Version placeholder end -->
