### PR TITLE
fix: targets endpoint was returning empty array when target doesn't have batchs

### DIFF
--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/cluster/ControllerClusterManager.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/cluster/ControllerClusterManager.java
@@ -157,8 +157,9 @@ public class ControllerClusterManager extends AbstractService<ControllerClusterM
                                 int size = channelMetrics.size();
                                 int reducedSize = (int) Math.ceil((float) size / clusterSize);
                                 log.debug(
-                                    "[{}] Maximum '{}' channels will be scheduled for re-balancing",
+                                    "[{}] Maximum '{}' channels for target '{}'} will be scheduled for re-balancing",
                                     identifyConfiguration.id(),
+                                    group.getKey(),
                                     reducedSize
                                 );
                                 // Filter channel with pending commands


### PR DESCRIPTION
**Issue**

Link to the original issue

**Description**

Targets endpoint was returning empty array when target doesn't have batchs, by removing the zipWith this PR fixes the issue.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.7.5-fix-targets-endpoint-with-batchs-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/exchange/gravitee-exchange/1.7.5-fix-targets-endpoint-with-batchs-SNAPSHOT/gravitee-exchange-1.7.5-fix-targets-endpoint-with-batchs-SNAPSHOT.zip)
  <!-- Version placeholder end -->
