### PR TITLE
feat: handle blocking code during authentication 

### DIFF
--- a/gravitee-exchange-controller/gravitee-exchange-controller-websocket/src/main/java/io/gravitee/exchange/controller/websocket/FailureHandler.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-websocket/src/main/java/io/gravitee/exchange/controller/websocket/FailureHandler.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.exchange.controller.websocket;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.rxjava3.ext.web.RoutingContext;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class FailureHandler implements io.vertx.core.Handler<RoutingContext> {
+
+    @Override
+    public void handle(final RoutingContext ctx) {
+        log.error("Caught failure", ctx.failure());
+        ctx.response().putHeader("content-type", "application/json").setStatusCode(500).end().subscribe();
+    }
+}

--- a/gravitee-exchange-controller/gravitee-exchange-controller-websocket/src/main/java/io/gravitee/exchange/controller/websocket/WebSocketRequestHandler.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-websocket/src/main/java/io/gravitee/exchange/controller/websocket/WebSocketRequestHandler.java
@@ -25,14 +25,13 @@ import io.gravitee.exchange.api.command.CommandHandler;
 import io.gravitee.exchange.api.command.Reply;
 import io.gravitee.exchange.api.command.ReplyAdapter;
 import io.gravitee.exchange.api.controller.ControllerChannel;
-import io.gravitee.exchange.api.controller.ControllerCommandContext;
 import io.gravitee.exchange.api.controller.ControllerCommandHandlersFactory;
 import io.gravitee.exchange.api.controller.ExchangeController;
 import io.gravitee.exchange.api.websocket.command.ExchangeSerDe;
 import io.gravitee.exchange.api.websocket.protocol.ProtocolVersion;
 import io.gravitee.exchange.controller.websocket.auth.WebSocketControllerAuthentication;
 import io.gravitee.exchange.controller.websocket.channel.WebSocketControllerChannel;
-import io.gravitee.node.api.Node;
+import io.reactivex.rxjava3.core.Maybe;
 import io.vertx.rxjava3.core.Vertx;
 import io.vertx.rxjava3.core.http.HttpServerRequest;
 import io.vertx.rxjava3.ext.web.RoutingContext;
@@ -63,49 +62,65 @@ public class WebSocketRequestHandler implements io.vertx.core.Handler<io.vertx.r
 
         log.debug("Incoming connection on Websocket Controller");
         HttpServerRequest request = routingContext.request();
-        ControllerCommandContext controllerContext = controllerAuthentication.authenticate(request);
-        if (controllerContext.isValid()) {
-            // Resolve protocol version from header
-            String headerValue = request.getHeader(EXCHANGE_PROTOCOL_HEADER);
-            ProtocolVersion protocolVersion = ProtocolVersion.parse(headerValue);
 
-            request
-                .toWebSocket()
-                .flatMapCompletable(webSocket -> {
-                    List<CommandHandler<? extends Command<?>, ? extends Reply<?>>> commandHandlers =
-                        controllerCommandHandlersFactory.buildCommandHandlers(controllerContext);
-                    List<CommandAdapter<? extends Command<?>, ? extends Command<?>, ? extends Reply<?>>> commandAdapters =
-                        controllerCommandHandlersFactory.buildCommandAdapters(controllerContext, protocolVersion);
-                    List<ReplyAdapter<? extends Reply<?>, ? extends Reply<?>>> replyAdapters =
-                        controllerCommandHandlersFactory.buildReplyAdapters(controllerContext, protocolVersion);
+        request.pause();
 
-                    ControllerChannel websocketControllerChannel = new WebSocketControllerChannel(
-                        commandHandlers,
-                        commandAdapters,
-                        replyAdapters,
-                        vertx,
-                        webSocket,
-                        protocolVersion.adapterFactory().apply(commandSerDe)
-                    );
-                    return exchangeController
-                        .register(websocketControllerChannel)
-                        .doOnComplete(() ->
-                            webSocket.closeHandler(v ->
-                                exchangeController.unregister(websocketControllerChannel).onErrorComplete().subscribe()
-                            )
-                        )
-                        .doOnError(throwable -> {
-                            log.error("Unable to register websocket channel");
-                            webSocket.close((short) 1011, "Unexpected error while registering channel").subscribe();
-                        })
-                        .onErrorComplete();
+        vertx
+            .rxExecuteBlocking(() -> {
+                var context = controllerAuthentication.authenticate(request);
+
+                if (context.isValid()) {
+                    return context;
+                }
+                return null;
+            })
+            .switchIfEmpty(
+                Maybe.fromRunnable(() -> {
+                    // Authentication failed so reject the request
+                    log.debug("Unauthorized request on Websocket Controller");
+                    routingContext.fail(HttpStatusCode.UNAUTHORIZED_401);
                 })
-                .doOnError(throwable -> routingContext.fail(HttpStatusCode.INTERNAL_SERVER_ERROR_500))
-                .subscribe();
-        } else {
-            // Authentication failed so reject the request
-            log.debug("Unauthorized request on Websocket Controller");
-            routingContext.fail(HttpStatusCode.UNAUTHORIZED_401);
-        }
+            )
+            .flatMapCompletable(controllerContext -> {
+                request.resume();
+
+                // Resolve protocol version from header
+                String headerValue = request.getHeader(EXCHANGE_PROTOCOL_HEADER);
+                ProtocolVersion protocolVersion = ProtocolVersion.parse(headerValue);
+
+                return request
+                    .toWebSocket()
+                    .flatMapCompletable(webSocket -> {
+                        List<CommandHandler<? extends Command<?>, ? extends Reply<?>>> commandHandlers =
+                            controllerCommandHandlersFactory.buildCommandHandlers(controllerContext);
+                        List<CommandAdapter<? extends Command<?>, ? extends Command<?>, ? extends Reply<?>>> commandAdapters =
+                            controllerCommandHandlersFactory.buildCommandAdapters(controllerContext, protocolVersion);
+                        List<ReplyAdapter<? extends Reply<?>, ? extends Reply<?>>> replyAdapters =
+                            controllerCommandHandlersFactory.buildReplyAdapters(controllerContext, protocolVersion);
+
+                        ControllerChannel websocketControllerChannel = new WebSocketControllerChannel(
+                            commandHandlers,
+                            commandAdapters,
+                            replyAdapters,
+                            vertx,
+                            webSocket,
+                            protocolVersion.adapterFactory().apply(commandSerDe)
+                        );
+                        return exchangeController
+                            .register(websocketControllerChannel)
+                            .doOnComplete(() ->
+                                webSocket.closeHandler(v ->
+                                    exchangeController.unregister(websocketControllerChannel).onErrorComplete().subscribe()
+                                )
+                            )
+                            .doOnError(throwable -> {
+                                log.error("Unable to register websocket channel");
+                                webSocket.close((short) 1011, "Unexpected error while registering channel").subscribe();
+                            })
+                            .onErrorComplete();
+                    })
+                    .doOnError(throwable -> routingContext.fail(HttpStatusCode.INTERNAL_SERVER_ERROR_500));
+            })
+            .subscribe();
     }
 }

--- a/gravitee-exchange-controller/gravitee-exchange-controller-websocket/src/main/java/io/gravitee/exchange/controller/websocket/server/WebSocketControllerServerVerticle.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-websocket/src/main/java/io/gravitee/exchange/controller/websocket/server/WebSocketControllerServerVerticle.java
@@ -20,6 +20,7 @@ import static io.gravitee.exchange.api.controller.ws.WebsocketControllerConstant
 import static io.gravitee.exchange.api.controller.ws.WebsocketControllerConstants.LEGACY_CONTROLLER_PATH;
 
 import io.gravitee.exchange.api.websocket.protocol.ProtocolVersion;
+import io.gravitee.exchange.controller.websocket.FailureHandler;
 import io.gravitee.exchange.controller.websocket.WebSocketRequestHandler;
 import io.reactivex.rxjava3.core.Completable;
 import io.vertx.rxjava3.core.AbstractVerticle;
@@ -38,17 +39,19 @@ public class WebSocketControllerServerVerticle extends AbstractVerticle {
 
     private final HttpServer controllerWebSocketHttpServer;
     private final WebSocketRequestHandler webSocketRequestHandler;
+    private final FailureHandler failureHandler = new FailureHandler();
 
     @Override
     public Completable rxStart() {
         Router router = Router.router(vertx);
-        router.route(EXCHANGE_CONTROLLER_PATH).handler(webSocketRequestHandler);
+        router.route(EXCHANGE_CONTROLLER_PATH).handler(webSocketRequestHandler).failureHandler(failureHandler);
         router
             .route(LEGACY_CONTROLLER_PATH)
             .handler(ctx -> {
                 ctx.request().headers().add(EXCHANGE_PROTOCOL_HEADER, ProtocolVersion.LEGACY.version());
                 webSocketRequestHandler.handle(ctx);
-            });
+            })
+            .failureHandler(failureHandler);
         // Default non-handled requests:
         router.route().handler(ctx -> ctx.fail(404));
 


### PR DESCRIPTION
**Description**

Implementing rxAuthenticate allows user to run async code in the authentication controller.
For example, in APIM we fetch data in the Database to authenticate the request. This call can block the event loop throwing Thread blocked exception.

I've added a default method for `rxAuthenticate` to prevent breaking changes and allow a smooth upgrade if there is no need for Rx, like in Cockpit.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.9.0-rxify-websocket-authentication-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/exchange/gravitee-exchange/1.9.0-rxify-websocket-authentication-SNAPSHOT/gravitee-exchange-1.9.0-rxify-websocket-authentication-SNAPSHOT.zip)
  <!-- Version placeholder end -->
