### PR TITLE
Archi 391 fix channel status consistency

### DIFF
--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/DefaultExchangeController.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/DefaultExchangeController.java
@@ -127,8 +127,8 @@ public class DefaultExchangeController extends AbstractService<ExchangeControlle
 
     @Override
     protected void doStart() throws Exception {
-        log.debug("[{}] Starting {} controller", this.identifyConfiguration.id(), this.getClass().getSimpleName());
         super.doStart();
+        log.debug("[{}] Starting {} controller", this.identifyConfiguration.id(), this.getClass().getSimpleName());
         controllerClusterManager.start();
         startBatchFeature();
 
@@ -233,8 +233,8 @@ public class DefaultExchangeController extends AbstractService<ExchangeControlle
 
     @Override
     protected void doStop() throws Exception {
-        log.debug("[{}] Stopping {} controller", this.identifyConfiguration.id(), this.getClass().getSimpleName());
         super.doStop();
+        log.debug("[{}] Stopping {} controller", this.identifyConfiguration.id(), this.getClass().getSimpleName());
 
         if (primaryChannelEvictedTopic != null && primaryChannelEvictedSubscriptionId != null) {
             primaryChannelEvictedTopic.removeMessageListener(primaryChannelEvictedSubscriptionId);

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/channel/primary/PrimaryChannelCandidateHealthcheckEvent.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/channel/primary/PrimaryChannelCandidateHealthcheckEvent.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.exchange.controller.core.channel.primary;
+
+import java.io.Serializable;
+import java.time.Instant;
+import lombok.Builder;
+
+@Builder
+public record PrimaryChannelCandidateHealthcheckEvent(Instant eventTime, String channelId, String responseQueue) implements Serializable {
+    @Builder
+    public record Response(Instant requestEventTime, String channelId, String targetId, boolean active) implements Serializable {}
+}

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/channel/primary/PrimaryChannelCandidateRegistry.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/channel/primary/PrimaryChannelCandidateRegistry.java
@@ -16,7 +16,9 @@
 package io.gravitee.exchange.controller.core.channel.primary;
 
 import io.gravitee.node.api.cache.Cache;
+import io.reactivex.rxjava3.core.Flowable;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 
@@ -24,6 +26,10 @@ import lombok.RequiredArgsConstructor;
 public class PrimaryChannelCandidateRegistry {
 
     private final Cache<String, Set<String>> store;
+
+    public Flowable<Map.Entry<String, Set<String>>> rxEntrySet() {
+        return store.rxEntrySet();
+    }
 
     public Set<String> get(final String targetId) {
         if (targetId == null) {

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/channel/primary/PrimaryChannelManager.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/channel/primary/PrimaryChannelManager.java
@@ -51,8 +51,8 @@ public class PrimaryChannelManager extends AbstractService<PrimaryChannelManager
 
     @Override
     protected void doStart() throws Exception {
-        log.debug("[{}] Starting primary channel manager", this.identifyConfiguration.id());
         super.doStart();
+        log.debug("[{}] Starting primary channel manager", this.identifyConfiguration.id());
         CacheConfiguration cacheConfiguration = CacheConfiguration.builder().distributed(true).build();
         if (primaryChannelCandidateRegistry == null) {
             primaryChannelCandidateRegistry =
@@ -68,8 +68,8 @@ public class PrimaryChannelManager extends AbstractService<PrimaryChannelManager
 
     @Override
     protected void doStop() throws Exception {
-        log.debug("[{}] Stopping primary channel manager", this.identifyConfiguration.id());
         super.doStop();
+        log.debug("[{}] Stopping primary channel manager", this.identifyConfiguration.id());
     }
 
     public boolean isPrimaryChannelFor(final String channelId, final String targetId) {

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/channel/primary/PrimaryChannelManager.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/channel/primary/PrimaryChannelManager.java
@@ -17,15 +17,30 @@ package io.gravitee.exchange.controller.core.channel.primary;
 
 import io.gravitee.common.service.AbstractService;
 import io.gravitee.exchange.api.configuration.IdentifyConfiguration;
+import io.gravitee.exchange.api.controller.ControllerChannel;
+import io.gravitee.exchange.controller.core.channel.ChannelManager;
 import io.gravitee.node.api.cache.Cache;
 import io.gravitee.node.api.cache.CacheConfiguration;
 import io.gravitee.node.api.cache.CacheManager;
 import io.gravitee.node.api.cluster.ClusterManager;
+import io.gravitee.node.api.cluster.Member;
+import io.gravitee.node.api.cluster.MemberListener;
+import io.gravitee.node.api.cluster.messaging.Queue;
 import io.gravitee.node.api.cluster.messaging.Topic;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.MaybeEmitter;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -41,35 +56,221 @@ public class PrimaryChannelManager extends AbstractService<PrimaryChannelManager
     public static final String PRIMARY_CHANNEL_EVICTED_EVENTS_TOPIC = "controller-primary-channel-evicted-events";
     public static final String PRIMARY_CHANNEL_CACHE = "controller-primary-channel";
     public static final String PRIMARY_CHANNEL_CANDIDATE_CACHE = "controller-primary-channel-candidate";
+    public static final String PRIMARY_CHANNEL_CANDIDATE_HEALTHCHECK_EVENTS_TOPIC =
+        "controller-primary-channel-candidate-healthcheck-events";
+    private static final int PRIMARY_CHANNEL_CANDIDATE_HEALTH_CHECK_DELAY = 1_000;
+    private static final TimeUnit PRIMARY_CHANNEL_CANDIDATE_HEALTH_CHECK_DELAY_UNIT = TimeUnit.MILLISECONDS;
     private final IdentifyConfiguration identifyConfiguration;
     private final ClusterManager clusterManager;
     private final CacheManager cacheManager;
+    private final ChannelManager channelManager;
+    private final Map<String, MaybeEmitter<String>> candidateHealthCheckResponseEmitters = new ConcurrentHashMap<>();
     private PrimaryChannelCandidateRegistry primaryChannelCandidateRegistry;
     private Cache<String, String> primaryChannelRegistry;
     private Topic<PrimaryChannelElectedEvent> primaryChannelElectedEventTopic;
     private Topic<PrimaryChannelEvictedEvent> primaryChannelEvictedEventTopic;
+    private Topic<PrimaryChannelCandidateHealthcheckEvent> primaryChannelHealthcheckEventTopic;
+    private String primaryChannelHealthcheckSubscriptionId;
+    private MemberListener primaryChannelHealthCheckListener;
+    private Queue<PrimaryChannelCandidateHealthcheckEvent.Response> primaryChannelCandidatesHealthcheckResponseQueue;
+    private String primaryChannelCandidatesHealthcheckResponseEventListenerId;
+    private String primaryChannelCandidatesHealthcheckResponseQueueName;
 
     @Override
     protected void doStart() throws Exception {
         super.doStart();
         log.debug("[{}] Starting primary channel manager", this.identifyConfiguration.id());
         CacheConfiguration cacheConfiguration = CacheConfiguration.builder().distributed(true).build();
-        if (primaryChannelCandidateRegistry == null) {
-            primaryChannelCandidateRegistry =
-                new PrimaryChannelCandidateRegistry(
-                    cacheManager.getOrCreateCache(identifyConfiguration.identifyName(PRIMARY_CHANNEL_CANDIDATE_CACHE), cacheConfiguration)
-                );
-        }
+        primaryChannelCandidateRegistry =
+            new PrimaryChannelCandidateRegistry(
+                cacheManager.getOrCreateCache(identifyConfiguration.identifyName(PRIMARY_CHANNEL_CANDIDATE_CACHE), cacheConfiguration)
+            );
         primaryChannelRegistry =
             cacheManager.getOrCreateCache(identifyConfiguration.identifyName(PRIMARY_CHANNEL_CACHE), cacheConfiguration);
         primaryChannelElectedEventTopic = clusterManager.topic(identifyConfiguration.identifyName(PRIMARY_CHANNEL_ELECTED_EVENTS_TOPIC));
         primaryChannelEvictedEventTopic = clusterManager.topic(identifyConfiguration.identifyName(PRIMARY_CHANNEL_EVICTED_EVENTS_TOPIC));
+
+        /*
+         * Handle primary candidate health mechanism
+         * When a cluster member is leaving, we must ensure that all known candidates are still connected.
+         *
+         * The mechanism use :
+         *   - a topic where channel candidate healthcheck event will be sent and received by all controllers on the cluster
+         *   - each controller depending on its locally connected channel will respond to a dynamic response queue
+         *   - the node at the original of the healthCheck event will publish a ChannelEvent message accordingly
+         *   - if no response is received before the defined delay, the channel is discarded from the candidate list
+         */
+        primaryChannelHealthcheckEventTopic =
+            clusterManager.topic(identifyConfiguration.identifyName(PRIMARY_CHANNEL_CANDIDATE_HEALTHCHECK_EVENTS_TOPIC));
+        primaryChannelHealthcheckSubscriptionId =
+            primaryChannelHealthcheckEventTopic.addMessageListener(message ->
+                handlePrimaryChannelCandidateHealthcheckEvent(message.content())
+            );
+        primaryChannelCandidatesHealthcheckResponseQueueName =
+            this.identifyConfiguration.identifyName("controller-primary-channel-candidates-healthcheck-response-" + UUID.randomUUID());
+        primaryChannelCandidatesHealthcheckResponseQueue = clusterManager.queue(primaryChannelCandidatesHealthcheckResponseQueueName);
+        primaryChannelCandidatesHealthcheckResponseEventListenerId =
+            primaryChannelCandidatesHealthcheckResponseQueue.addMessageListener(message ->
+                handlePrimaryChannelCandidateHealthcheckResponse(message.content())
+            );
+        primaryChannelHealthCheckListener =
+            new MemberListener() {
+                @Override
+                public void onMemberRemoved(final Member member) {
+                    sendPrimaryChannelCandidatesHealthCheck();
+                }
+            };
+        clusterManager.addMemberListener(primaryChannelHealthCheckListener);
+    }
+
+    private void handlePrimaryChannelCandidateHealthcheckEvent(final PrimaryChannelCandidateHealthcheckEvent event) {
+        if (Instant.now().isBefore(event.eventTime().plus(PRIMARY_CHANNEL_CANDIDATE_HEALTH_CHECK_DELAY, ChronoUnit.MILLIS))) {
+            log.debug(
+                "[{}] Receiving primary channel candidate healthcheck event for channel '{}'",
+                this.identifyConfiguration.id(),
+                event.channelId()
+            );
+            Optional<ControllerChannel> channelOptional = channelManager.getChannelById(event.channelId());
+            if (channelOptional.isPresent()) {
+                ControllerChannel controllerChannel = channelOptional.get();
+                log.debug(
+                    "[{}] Responding to primary channel candidate event for channel '{}' on target '{}'",
+                    this.identifyConfiguration.id(),
+                    controllerChannel.id(),
+                    controllerChannel.targetId()
+                );
+                PrimaryChannelCandidateHealthcheckEvent.Response responseEvent = PrimaryChannelCandidateHealthcheckEvent.Response
+                    .builder()
+                    .requestEventTime(event.eventTime())
+                    .channelId(controllerChannel.id())
+                    .targetId(controllerChannel.targetId())
+                    .active(controllerChannel.isActive())
+                    .build();
+                clusterManager.queue(event.responseQueue()).add(responseEvent);
+            } else {
+                log.debug(
+                    "[{}] Ignoring primary channel candidate healthcheck because channel '{}' is not connected to this controller",
+                    this.identifyConfiguration.id(),
+                    event.channelId()
+                );
+            }
+        } else {
+            log.debug(
+                "[{}] Ignoring expired primary channel candidate healthcheck for channel '{}'",
+                this.identifyConfiguration.id(),
+                event.channelId()
+            );
+        }
+    }
+
+    private void handlePrimaryChannelCandidateHealthcheckResponse(final PrimaryChannelCandidateHealthcheckEvent.Response responseEvent) {
+        log.debug(
+            "[{}] Healthcheck response received for primary channel candidate '{}' for target '{}'",
+            this.identifyConfiguration.id(),
+            responseEvent.channelId(),
+            responseEvent.targetId()
+        );
+
+        MaybeEmitter<String> maybeEmitter = candidateHealthCheckResponseEmitters.remove(responseEvent.channelId());
+        if (maybeEmitter != null) {
+            channelManager.publishChannelEvent(responseEvent.channelId(), responseEvent.targetId(), responseEvent.active(), false);
+            maybeEmitter.onSuccess(responseEvent.channelId());
+        } else {
+            log.debug(
+                "[{}] Ignoring expired healthcheck response for primary channel candidate '{}' for target '{}'",
+                this.identifyConfiguration.id(),
+                responseEvent.channelId(),
+                responseEvent.targetId()
+            );
+        }
+    }
+
+    private void sendPrimaryChannelCandidatesHealthCheck() {
+        if (clusterManager.self().primary()) {
+            log.debug("[{}] Checking primary channel candidates health", this.identifyConfiguration.id());
+            primaryChannelCandidateRegistry
+                .rxEntrySet()
+                .flatMapCompletable(entry -> {
+                    String targetId = entry.getKey();
+                    return Flowable
+                        .fromIterable(entry.getValue())
+                        .filter(channelId -> !candidateHealthCheckResponseEmitters.containsKey(channelId))
+                        .flatMapCompletable(channelId ->
+                            Completable
+                                .mergeArray(
+                                    Maybe
+                                        .<String>create(emitter -> candidateHealthCheckResponseEmitters.put(channelId, emitter))
+                                        .timeout(
+                                            PRIMARY_CHANNEL_CANDIDATE_HEALTH_CHECK_DELAY,
+                                            PRIMARY_CHANNEL_CANDIDATE_HEALTH_CHECK_DELAY_UNIT,
+                                            Maybe.fromRunnable(() -> {
+                                                log.warn(
+                                                    "[{}] No healthcheck response received for primary channel candidate '{}' for target '{}'",
+                                                    this.identifyConfiguration.id(),
+                                                    channelId,
+                                                    targetId
+                                                );
+                                                channelManager.publishChannelEvent(channelId, targetId, false, true);
+                                            })
+                                        )
+                                        .ignoreElement(),
+                                    Completable
+                                        .fromRunnable(() ->
+                                            log.debug(
+                                                "[{}] Sending primary channel candidate healthcheck for channel '{}' on target '{}'",
+                                                this.identifyConfiguration.id(),
+                                                channelId,
+                                                targetId
+                                            )
+                                        )
+                                        .andThen(
+                                            primaryChannelHealthcheckEventTopic.rxPublish(
+                                                PrimaryChannelCandidateHealthcheckEvent
+                                                    .builder()
+                                                    .eventTime(Instant.now())
+                                                    .channelId(channelId)
+                                                    .responseQueue(primaryChannelCandidatesHealthcheckResponseQueueName)
+                                                    .build()
+                                            )
+                                        )
+                                )
+                                .onErrorResumeNext(throwable -> {
+                                    log.warn(
+                                        "[{}] Unable to check primary channel candidate health '{}' for target '{}'",
+                                        this.identifyConfiguration.id(),
+                                        entry.getValue(),
+                                        targetId,
+                                        throwable
+                                    );
+                                    return Completable.complete();
+                                })
+                                .doFinally(() -> candidateHealthCheckResponseEmitters.remove(channelId))
+                        );
+                })
+                .onErrorComplete()
+                .blockingAwait();
+        }
     }
 
     @Override
     protected void doStop() throws Exception {
         super.doStop();
         log.debug("[{}] Stopping primary channel manager", this.identifyConfiguration.id());
+
+        // Remove listeners for Primary channel candidates health check
+        if (primaryChannelHealthCheckListener != null) {
+            clusterManager.removeMemberListener(primaryChannelHealthCheckListener);
+        }
+        if (
+            primaryChannelCandidatesHealthcheckResponseQueue != null && primaryChannelCandidatesHealthcheckResponseEventListenerId != null
+        ) {
+            primaryChannelCandidatesHealthcheckResponseQueue.removeMessageListener(
+                primaryChannelCandidatesHealthcheckResponseEventListenerId
+            );
+        }
+        if (primaryChannelHealthcheckEventTopic != null && primaryChannelHealthcheckSubscriptionId != null) {
+            primaryChannelHealthcheckEventTopic.removeMessageListener(primaryChannelHealthcheckSubscriptionId);
+        }
     }
 
     public boolean isPrimaryChannelFor(final String channelId, final String targetId) {

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/cluster/ControllerClusterManager.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/cluster/ControllerClusterManager.java
@@ -194,19 +194,17 @@ public class ControllerClusterManager extends AbstractService<ControllerClusterM
 
     @Override
     protected void doStop() throws Exception {
+        super.doStop();
         String message = "[%s] Stopping controller cluster manager".formatted(identifyConfiguration.id());
         log.debug(message);
-        super.doStop();
 
         // Stop all command listeners.
-        final List<ControllerChannel> channels = subscriptionsListenersByChannel
+        subscriptionsListenersByChannel
             .values()
             .stream()
             .map(id -> channelManager.getChannelById(id).orElse(null))
             .filter(Objects::nonNull)
-            .toList();
-
-        channels.forEach(this::channelDisconnected);
+            .forEach(this::channelDisconnected);
 
         // Remove member listener
         if (memberListener != null) {
@@ -227,7 +225,9 @@ public class ControllerClusterManager extends AbstractService<ControllerClusterM
         }
 
         // Finally, notify all pending Rx emitters with an error.
-        resultEmittersByCommand.forEach((type, emitter) -> emitter.onError(new ControllerClusterShutdownException(message)));
+        resultEmittersByCommand.forEach((type, emitter) ->
+            emitter.onError(new ControllerClusterShutdownException("Stopping controller cluster manager"))
+        );
         resultEmittersByCommand.clear();
     }
 

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/channel/primary/PrimaryChannelManagerTest.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/channel/primary/PrimaryChannelManagerTest.java
@@ -17,23 +17,30 @@ package io.gravitee.exchange.controller.core.channel.primary;
 
 import static io.gravitee.exchange.controller.core.channel.primary.PrimaryChannelManager.PRIMARY_CHANNEL_CACHE;
 import static io.gravitee.exchange.controller.core.channel.primary.PrimaryChannelManager.PRIMARY_CHANNEL_CANDIDATE_CACHE;
+import static io.gravitee.exchange.controller.core.channel.primary.PrimaryChannelManager.PRIMARY_CHANNEL_CANDIDATE_HEALTHCHECK_EVENTS_TOPIC;
 import static io.gravitee.exchange.controller.core.channel.primary.PrimaryChannelManager.PRIMARY_CHANNEL_ELECTED_EVENTS_TOPIC;
 import static io.gravitee.exchange.controller.core.channel.primary.PrimaryChannelManager.PRIMARY_CHANNEL_EVICTED_EVENTS_TOPIC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import io.gravitee.exchange.api.configuration.IdentifyConfiguration;
+import io.gravitee.exchange.controller.core.channel.ChannelManager;
+import io.gravitee.exchange.controller.core.cluster.MultiMemberStandaloneClusterManager;
 import io.gravitee.node.api.cache.Cache;
 import io.gravitee.node.api.cache.CacheConfiguration;
 import io.gravitee.node.api.cache.CacheManager;
-import io.gravitee.node.api.cluster.ClusterManager;
+import io.gravitee.node.api.cluster.Member;
+import io.gravitee.node.api.cluster.MemberListener;
 import io.gravitee.node.api.cluster.messaging.Topic;
 import io.gravitee.node.plugin.cache.standalone.StandaloneCacheManager;
-import io.gravitee.node.plugin.cluster.standalone.StandaloneClusterManager;
+import io.gravitee.node.plugin.cluster.standalone.StandaloneMember;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import java.time.Instant;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -43,6 +50,8 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.env.MockEnvironment;
 
 /**
@@ -50,11 +59,14 @@ import org.springframework.mock.env.MockEnvironment;
  * @author GraviteeSource Team
  */
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@ExtendWith(VertxExtension.class)
+@ExtendWith({ VertxExtension.class, MockitoExtension.class })
 class PrimaryChannelManagerTest {
 
+    @Mock
+    private ChannelManager mockChannelManager;
+
     private CacheManager cacheManager;
-    private ClusterManager clusterManager;
+    private MultiMemberStandaloneClusterManager clusterManager;
     private MockEnvironment environment;
     private IdentifyConfiguration identifyConfiguration;
     private PrimaryChannelManager cut;
@@ -62,6 +74,8 @@ class PrimaryChannelManagerTest {
     private Cache<String, Set<String>> primaryChannelCandidateCache;
     private Topic<PrimaryChannelElectedEvent> primaryChannelElectedEventTopic;
     private Topic<PrimaryChannelEvictedEvent> primaryChannelEvictedEventTopic;
+    private Topic<PrimaryChannelCandidateHealthcheckEvent> primaryChannelHealthcheckEventTopic;
+    private MemberListener memberListener;
 
     @BeforeEach
     public void beforeEach(Vertx vertx) throws Exception {
@@ -69,9 +83,9 @@ class PrimaryChannelManagerTest {
         identifyConfiguration = new IdentifyConfiguration(environment);
         cacheManager = new StandaloneCacheManager();
         cacheManager.start();
-        clusterManager = new StandaloneClusterManager(vertx);
+        clusterManager = new MultiMemberStandaloneClusterManager(vertx);
         clusterManager.start();
-        cut = new PrimaryChannelManager(identifyConfiguration, clusterManager, cacheManager);
+        cut = new PrimaryChannelManager(identifyConfiguration, clusterManager, cacheManager, mockChannelManager);
         cut.start();
 
         CacheConfiguration cacheConfiguration = CacheConfiguration.builder().distributed(true).build();
@@ -80,11 +94,16 @@ class PrimaryChannelManagerTest {
             cacheManager.getOrCreateCache(identifyConfiguration.identifyName(PRIMARY_CHANNEL_CANDIDATE_CACHE), cacheConfiguration);
         primaryChannelElectedEventTopic = clusterManager.topic(identifyConfiguration.identifyName(PRIMARY_CHANNEL_ELECTED_EVENTS_TOPIC));
         primaryChannelEvictedEventTopic = clusterManager.topic(identifyConfiguration.identifyName(PRIMARY_CHANNEL_EVICTED_EVENTS_TOPIC));
+        primaryChannelHealthcheckEventTopic =
+            clusterManager.topic(identifyConfiguration.identifyName(PRIMARY_CHANNEL_CANDIDATE_HEALTHCHECK_EVENTS_TOPIC));
     }
 
     @AfterEach
     public void afterEach() {
         primaryChannelCache.clear();
+        if (memberListener != null) {
+            clusterManager.removeMemberListener(memberListener);
+        }
     }
 
     @Test
@@ -145,5 +164,75 @@ class PrimaryChannelManagerTest {
                 assertThat(primaryChannelCandidateCache.get("targetId")).containsOnly("channelId2");
                 assertThat(cut.isPrimaryChannelFor("channelId2", "targetId")).isTrue();
             });
+    }
+
+    @Test
+    void should_send_channel_candidate_healthcheck_when_member_is_leaving(VertxTestContext vertxTestContext) throws InterruptedException {
+        Checkpoint checkpoint = vertxTestContext.checkpoint(3); // 1 for leaving member; 2 for healtchcheck event        memberListener = memberListener(checkpoint);
+        StandaloneMember member = new StandaloneMember();
+        clusterManager.addMember(member);
+        memberListener = memberListener(checkpoint);
+        clusterManager.addMemberListener(memberListener);
+        primaryChannelCandidateCache.put("targetId", Set.of("channelId", "channelId2"));
+        primaryChannelHealthcheckEventTopic.addMessageListener(message -> {
+            checkpoint.flag();
+            PrimaryChannelCandidateHealthcheckEvent content = message.content();
+            if (content.channelId().equals("channelId")) {
+                clusterManager
+                    .queue(content.responseQueue())
+                    .add(
+                        PrimaryChannelCandidateHealthcheckEvent.Response
+                            .builder()
+                            .requestEventTime(content.eventTime())
+                            .channelId("channelId")
+                            .targetId("targetId")
+                            .active(true)
+                            .build()
+                    );
+            }
+        });
+        clusterManager.removeMember(member);
+        assertThat(vertxTestContext.awaitCompletion(10, TimeUnit.SECONDS)).isTrue();
+        verify(mockChannelManager, times(1)).publishChannelEvent("channelId", "targetId", true, false);
+        verify(mockChannelManager, times(1)).publishChannelEvent("channelId2", "targetId", false, true);
+    }
+
+    @Test
+    void should_ignore_primary_candidate_healthcheck_response_when_timestamp_is_old(VertxTestContext vertxTestContext)
+        throws InterruptedException {
+        Checkpoint checkpoint = vertxTestContext.checkpoint(2); // 1 for leaving member; 1 for healtchcheck event        memberListener = memberListener(checkpoint);
+        StandaloneMember member = new StandaloneMember();
+        clusterManager.addMember(member);
+        memberListener = memberListener(checkpoint);
+        clusterManager.addMemberListener(memberListener);
+        primaryChannelCandidateCache.put("targetId", Set.of("channelId"));
+        primaryChannelHealthcheckEventTopic.addMessageListener(message -> {
+            checkpoint.flag();
+            PrimaryChannelCandidateHealthcheckEvent content = message.content();
+            await().atLeast(1000, TimeUnit.MILLISECONDS).until(() -> true);
+            clusterManager
+                .queue(content.responseQueue())
+                .add(
+                    PrimaryChannelCandidateHealthcheckEvent.Response
+                        .builder()
+                        .requestEventTime(Instant.MIN)
+                        .channelId("channelId")
+                        .targetId("targetId")
+                        .active(true)
+                        .build()
+                );
+        });
+        clusterManager.removeMember(member);
+        assertThat(vertxTestContext.awaitCompletion(10, TimeUnit.SECONDS)).isTrue();
+        verify(mockChannelManager, times(0)).publishChannelEvent("channelId", "targetId", true, false);
+    }
+
+    private static MemberListener memberListener(final Checkpoint checkpoint) {
+        return new MemberListener() {
+            @Override
+            public void onMemberRemoved(final Member member) {
+                checkpoint.flag();
+            }
+        };
     }
 }

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/cluster/ControllerClusterManagerTest.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/cluster/ControllerClusterManagerTest.java
@@ -55,7 +55,6 @@ class ControllerClusterManagerTest {
     private MockEnvironment environment;
     private IdentifyConfiguration identifyConfiguration;
     private ControllerClusterManager cut;
-    private Queue<ChannelEvent> channelEventQueue;
     private MemberListener memberListener;
 
     @BeforeEach
@@ -72,7 +71,6 @@ class ControllerClusterManagerTest {
         clusterManager.start();
         cut = new ControllerClusterManager(identifyConfiguration, clusterManager, cacheManager);
         cut.start();
-        channelEventQueue = clusterManager.queue(identifyConfiguration.identifyName(ChannelManager.CHANNEL_EVENTS_QUEUE));
     }
 
     @AfterEach
@@ -188,9 +186,6 @@ class ControllerClusterManagerTest {
             public void onMemberAdded(final Member member) {
                 checkpoint.flag();
             }
-
-            @Override
-            public void onMemberRemoved(final Member member) {}
         };
     }
 }

--- a/gravitee-exchange-controller/gravitee-exchange-controller-websocket/src/main/java/io/gravitee/exchange/controller/websocket/WebSocketExchangeController.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-websocket/src/main/java/io/gravitee/exchange/controller/websocket/WebSocketExchangeController.java
@@ -200,12 +200,12 @@ public class WebSocketExchangeController extends DefaultExchangeController imple
 
     private void undeployVerticle() {
         if (websocketServerVerticleId != null) {
-            vertx
-                .undeploy(websocketServerVerticleId)
-                .subscribe(
-                    () -> log.info("Exchange Controller Websocket undeployed successfully"),
-                    throwable -> log.error("Unable to undeploy Exchange Controller Websocket", throwable)
-                );
+            try {
+                vertx.undeploy(websocketServerVerticleId).blockingAwait(); // Need to be "blocking" to make sure it is done before continuing
+                log.info("Exchange Controller Websocket undeployed successfully");
+            } catch (Exception e) {
+                log.error("Unable to undeploy Exchange Controller Websocket", e);
+            }
         }
     }
 }

--- a/gravitee-exchange-controller/gravitee-exchange-controller-websocket/src/main/java/io/gravitee/exchange/controller/websocket/WebSocketRequestHandler.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-websocket/src/main/java/io/gravitee/exchange/controller/websocket/WebSocketRequestHandler.java
@@ -17,6 +17,7 @@ package io.gravitee.exchange.controller.websocket;
 
 import static io.gravitee.exchange.api.controller.ws.WebsocketControllerConstants.EXCHANGE_PROTOCOL_HEADER;
 
+import io.gravitee.common.component.Lifecycle;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.exchange.api.command.Command;
 import io.gravitee.exchange.api.command.CommandAdapter;
@@ -31,6 +32,7 @@ import io.gravitee.exchange.api.websocket.command.ExchangeSerDe;
 import io.gravitee.exchange.api.websocket.protocol.ProtocolVersion;
 import io.gravitee.exchange.controller.websocket.auth.WebSocketControllerAuthentication;
 import io.gravitee.exchange.controller.websocket.channel.WebSocketControllerChannel;
+import io.gravitee.node.api.Node;
 import io.vertx.rxjava3.core.Vertx;
 import io.vertx.rxjava3.core.http.HttpServerRequest;
 import io.vertx.rxjava3.ext.web.RoutingContext;
@@ -54,6 +56,11 @@ public class WebSocketRequestHandler implements io.vertx.core.Handler<io.vertx.r
 
     @Override
     public void handle(final RoutingContext routingContext) {
+        if (exchangeController.lifecycleState() != Lifecycle.State.STARTED) {
+            log.warn("Incoming connection rejected because Websocket Controller is stopping");
+            routingContext.fail(HttpStatusCode.GONE_410);
+        }
+
         log.debug("Incoming connection on Websocket Controller");
         HttpServerRequest request = routingContext.request();
         ControllerCommandContext controllerContext = controllerAuthentication.authenticate(request);

--- a/gravitee-exchange-controller/gravitee-exchange-controller-websocket/src/main/java/io/gravitee/exchange/controller/websocket/server/WebSocketControllerServerVerticle.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-websocket/src/main/java/io/gravitee/exchange/controller/websocket/server/WebSocketControllerServerVerticle.java
@@ -61,8 +61,10 @@ public class WebSocketControllerServerVerticle extends AbstractVerticle {
     }
 
     @Override
-    public void stop() {
-        log.info("Stopping Controller websocket server ...");
-        controllerWebSocketHttpServer.close().doFinally(() -> log.info("HTTP Server has been successfully stopped")).subscribe();
+    public Completable rxStop() {
+        return controllerWebSocketHttpServer
+            .close()
+            .doOnSubscribe(disposable -> log.info("Stopping Controller websocket server ..."))
+            .doFinally(() -> log.info("HTTP Server has been successfully stopped"));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <gravitee-bom.version>8.1.0</gravitee-bom.version>
         <gravitee-common.version>4.5.1</gravitee-common.version>
-        <gravitee-node.version>5.20.0</gravitee-node.version>
+        <gravitee-node.version>6.0.2</gravitee-node.version>
 
         <commons-lang3.version>3.15.0</commons-lang3.version>
         <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>


### PR DESCRIPTION
**Issue**
https://gravitee.atlassian.net/browse/ARCHI-391

**Description**

The PR attempts to fix an issue when a controller node crashes when dealing with some Event. The result is that caches can be inconsistent and lead to errors.

The following mechanism has also been implemented:

  - When a cluster member is leaving, we must ensure that all known candidates are still connected.
  - The mechanism use :
     - a topic where channel candidate health check event will be sent and received by all controllers on the cluster
     - each controller depending on its locally connected channel will respond to a dynamic response queue
     - the node at the original of the health check event will publish a ChannelEvent message accordingly
     - if no response is received before the defined delay, the channel is discarded from the candidate
**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.8.0-archi-391-fix-channel-status-consistency-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/exchange/gravitee-exchange/1.8.0-archi-391-fix-channel-status-consistency-SNAPSHOT/gravitee-exchange-1.8.0-archi-391-fix-channel-status-consistency-SNAPSHOT.zip)
  <!-- Version placeholder end -->
