### PR TITLE
fix: bump node version to 6.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <gravitee-bom.version>8.1.0</gravitee-bom.version>
         <gravitee-common.version>4.5.1</gravitee-common.version>
-        <gravitee-node.version>6.0.2</gravitee-node.version>
+        <gravitee-node.version>6.0.3</gravitee-node.version>
 
         <commons-lang3.version>3.15.0</commons-lang3.version>
         <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-391

**Description**

Just use latest version.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.8.1-archi-391-bump-node-version-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/exchange/gravitee-exchange/1.8.1-archi-391-bump-node-version-SNAPSHOT/gravitee-exchange-1.8.1-archi-391-bump-node-version-SNAPSHOT.zip)
  <!-- Version placeholder end -->
