### PR TITLE
Archi 391 handle thread blocked

### DIFF
--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/channel/AbstractWebSocketChannel.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/channel/AbstractWebSocketChannel.java
@@ -176,7 +176,7 @@ public abstract class AbstractWebSocketChannel implements Channel {
             return;
         }
 
-        log.debug("Handling received received command '{}' of type '{}'. Ignoring", command.getId(), command.getType());
+        log.trace("Handling received command '{}' of type '{}'", command.getId(), command.getType());
         Single<? extends Command<?>> commandObs;
         CommandAdapter<Command<?>, Command<?>, Reply<?>> commandAdapter =
             (CommandAdapter<Command<?>, Command<?>, Reply<?>>) commandAdapters.get(command.getType());
@@ -228,7 +228,7 @@ public abstract class AbstractWebSocketChannel implements Channel {
     private void receiveReply(final Reply<?> reply) {
         SingleEmitter<? extends Reply<?>> replyEmitter = resultEmitters.remove(reply.getCommandId());
         if (replyEmitter != null) {
-            log.debug("Handling received received reply '{}' of type '{}'. Ignoring", reply.getCommandId(), reply.getType());
+            log.trace("Handling received reply '{}' of type '{}'", reply.getCommandId(), reply.getType());
             Single<? extends Reply<?>> replyObs;
             ReplyAdapter<Reply<?>, Reply<?>> replyAdapter = (ReplyAdapter<Reply<?>, Reply<?>>) replyAdapters.get(reply.getType());
             if (replyAdapter != null) {
@@ -471,7 +471,7 @@ public abstract class AbstractWebSocketChannel implements Channel {
             return webSocket
                 .writeBinaryMessage(protocolAdapter.write(websocketExchange))
                 .doOnComplete(() ->
-                    log.debug(
+                    log.trace(
                         "Write exchange '{}' for '{}' and id '{}' to websocket successfully",
                         websocketExchange.type(),
                         websocketExchange.exchangeType(),

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/channel/ChannelManager.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/channel/ChannelManager.java
@@ -253,7 +253,7 @@ public class ChannelManager extends AbstractService<ChannelManager> {
     }
 
     private Completable sendHealthCheckCommand() {
-        log.debug("[{}] Sending healthcheck command to all registered channels", this.identifyConfiguration.id());
+        log.trace("[{}] Sending healthcheck command to all registered channels", this.identifyConfiguration.id());
         return Flowable
             .fromIterable(localChannelRegistry.getAll())
             .flatMapCompletable(controllerChannel ->


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-391

**Description**

This PR attempts to fix an issue occurring in some cases, when nodes come and leave., ThreadBlocked exception could occur when dealing with internal cache and queue. 
For example :
```
io.vertx.core.VertxException: Thread blocked
	at com.hazelcast.internal.serialization.impl.compact.RabinFingerprint.<clinit>(RabinFingerprint.java:29)
	at com.hazelcast.internal.serialization.impl.compact.Schema.init(Schema.java:129)
	at com.hazelcast.internal.serialization.impl.compact.Schema.<init>(Schema.java:57)
	at com.hazelcast.internal.serialization.impl.compact.SchemaWriter.build(SchemaWriter.java:52)
	at com.hazelcast.internal.serialization.impl.compact.CompactStreamSerializer.buildSchema(CompactStreamSerializer.java:397)
	at com.hazelcast.internal.serialization.impl.compact.CompactStreamSerializer.writeObject(CompactStreamSerializer.java:147)
	at com.hazelcast.internal.serialization.impl.compact.CompactStreamSerializer.write(CompactStreamSerializer.java:116)
	at com.hazelcast.internal.serialization.impl.compact.CompactStreamSerializer.write(CompactStreamSerializer.java:109)
	at com.hazelcast.internal.serialization.impl.StreamSerializerAdapter.write(StreamSerializerAdapter.java:39)
	at com.hazelcast.internal.serialization.impl.AbstractSerializationService.toBytes(AbstractSerializationService.java:238)
	at com.hazelcast.internal.serialization.impl.AbstractSerializationService.toBytes(AbstractSerializationService.java:217)
	at com.hazelcast.internal.serialization.impl.AbstractSerializationService.toData(AbstractSerializationService.java:202)
	at com.hazelcast.internal.serialization.impl.AbstractSerializationService.toData(AbstractSerializationService.java:157)
	at com.hazelcast.spi.impl.NodeEngineImpl.toData(NodeEngineImpl.java:419)
	at com.hazelcast.spi.impl.AbstractDistributedObject.toData(AbstractDistributedObject.java:82)
	at com.hazelcast.map.impl.proxy.MapProxyImpl.computeLocally(MapProxyImpl.java:1368)
	at com.hazelcast.map.impl.proxy.MapProxyImpl.compute(MapProxyImpl.java:1346)
	at io.gravitee.node.plugin.cache.hazelcast.HazelcastCache.compute(HazelcastCache.java:135)
	at io.gravitee.exchange.controller.core.channel.ChannelManager.updateChannelMetric(ChannelManager.java:242)
	at io.gravitee.exchange.controller.core.channel.ChannelManager.lambda$sendPrimaryCommand$12(ChannelManager.java:228)
	at io.gravitee.exchange.controller.core.channel.ChannelManager$$Lambda$5921/0x00007fc6f473fbb8.accept(Unknown Source)
	at io.reactivex.rxjava3.internal.operators.single.SingleDoOnSuccess$DoOnSuccess.onSuccess(SingleDoOnSuccess.java:54)
	at io.reactivex.rxjava3.internal.operators.single.SingleDoFinally$DoFinallyObserver.onSuccess(SingleDoFinally.java:73)
	at io.reactivex.rxjava3.internal.operators.single.SingleResumeNext$ResumeMainSingleObserver.onSuccess(SingleResumeNext.java:65)
	at io.reactivex.rxjava3.internal.operators.single.SingleFlatMap$SingleFlatMapCallback$FlatMapSingleObserver.onSuccess(SingleFlatMap.java:112)
	at io.reactivex.rxjava3.internal.operators.single.SingleTimeout$TimeoutMainObserver.onSuccess(SingleTimeout.java:137)
	at io.reactivex.rxjava3.internal.operators.single.SingleCreate$Emitter.onSuccess(SingleCreate.java:68)
	at io.gravitee.exchange.api.websocket.channel.AbstractWebSocketChannel.lambda$receiveReply$9(AbstractWebSocketChannel.java:246)
	at io.gravitee.exchange.api.websocket.channel.AbstractWebSocketChannel$$Lambda$4296/0x00007fc6f403e068.accept(Unknown Source)
	at io.reactivex.rxjava3.internal.operators.single.SingleDoOnSuccess$DoOnSuccess.onSuccess(SingleDoOnSuccess.java:54)
	at io.reactivex.rxjava3.internal.operators.single.SingleJust.subscribeActual(SingleJust.java:30)
	at io.reactivex.rxjava3.core.Single.subscribe(Single.java:4855)
	at io.reactivex.rxjava3.internal.operators.single.SingleDoOnSuccess.subscribeActual(SingleDoOnSuccess.java:35)
	at io.reactivex.rxjava3.core.Single.subscribe(Single.java:4855)
	at io.reactivex.rxjava3.internal.operators.single.SingleDoOnError.subscribeActual(SingleDoOnError.java:35)
	at io.reactivex.rxjava3.core.Single.subscribe(Single.java:4855)
	at io.reactivex.rxjava3.core.Single.subscribe(Single.java:4803)
	at io.reactivex.rxjava3.core.Single.subscribe(Single.java:4713)
	at io.gravitee.exchange.api.websocket.channel.AbstractWebSocketChannel.receiveReply(AbstractWebSocketChannel.java:256)
	at io.gravitee.exchange.api.websocket.channel.AbstractWebSocketChannel.lambda$initialize$3(AbstractWebSocketChannel.java:146)
	at io.gravitee.exchange.api.websocket.channel.AbstractWebSocketChannel$$Lambda$4174/0x00007fc6f3ff8f28.handle(Unknown Source)
	at io.vertx.lang.rx.DelegatingHandler.handle(DelegatingHandler.java:20)
	at io.vertx.core.http.impl.WebSocketImplBase$FrameAggregator.handleBinaryFrame(WebSocketImplBase.java:658)
	at io.vertx.core.http.impl.WebSocketImplBase$FrameAggregator.handle(WebSocketImplBase.java:603)
	at io.vertx.core.http.impl.WebSocketImplBase$FrameAggregator.handle(WebSocketImplBase.java:589)
	at io.vertx.core.impl.ContextInternal.dispatch(ContextInternal.java:279)
	at io.vertx.core.http.impl.WebSocketImplBase.receiveFrame(WebSocketImplBase.java:534)
	at io.vertx.core.http.impl.WebSocketImplBase$$Lambda$4154/0x00007fc6f3ff36a0.handle(Unknown Source)
	at io.vertx.core.streams.impl.InboundBuffer.handleEvent(InboundBuffer.java:255)
	at io.vertx.core.streams.impl.InboundBuffer.write(InboundBuffer.java:134)
	at io.vertx.core.http.impl.WebSocketImplBase.handleFrame(WebSocketImplBase.java:475)
	at io.vertx.core.http.impl.Http1xConnectionBase$$Lambda$4294/0x00007fc6f403a9e0.handle(Unknown Source)
	at io.vertx.core.impl.ContextImpl.execute(ContextImpl.java:313)
	at io.vertx.core.impl.DuplicatedContext.execute(DuplicatedContext.java:161)
	at io.vertx.core.http.impl.Http1xConnectionBase.handleWsFrame(Http1xConnectionBase.java:66)
	at io.vertx.core.http.impl.Http1xServerConnection.handleOther(Http1xServerConnection.java:191)
	at io.vertx.core.http.impl.Http1xServerConnection.handleMessage(Http1xServerConnection.java:176)
	at io.vertx.core.net.impl.ConnectionBase.read(ConnectionBase.java:159)
	at io.vertx.core.net.impl.VertxHandler.channelRead(VertxHandler.java:153)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base@17.0.9/java.lang.Thread.run(Unknown Source)
```
**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->