### PR TITLE
fix: add trace logging the payload sent through the socket

### DIFF
--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/channel/AbstractWebSocketChannel.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/channel/AbstractWebSocketChannel.java
@@ -468,8 +468,16 @@ public abstract class AbstractWebSocketChannel implements Channel {
 
     private Completable writeToSocket(final String commandId, final ProtocolExchange websocketExchange) {
         if (!webSocket.isClosed()) {
+            Buffer payload = protocolAdapter.write(websocketExchange);
+            log.trace(
+                "Writing exchange '{}' for '{}' for command id '{}' to websocket: {}",
+                websocketExchange.type(),
+                websocketExchange.exchangeType(),
+                commandId,
+                payload
+            );
             return webSocket
-                .writeBinaryMessage(protocolAdapter.write(websocketExchange))
+                .writeBinaryMessage(payload)
                 .doOnComplete(() ->
                     log.trace(
                         "Write exchange '{}' for '{}' and id '{}' to websocket successfully",


### PR DESCRIPTION
**Description**

For debugging purpose, a new TRACE log is added to log the payload sent through the socket.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.8.3-trace-command-sent-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/exchange/gravitee-exchange/1.8.3-trace-command-sent-SNAPSHOT/gravitee-exchange-1.8.3-trace-command-sent-SNAPSHOT.zip)
  <!-- Version placeholder end -->
