### PR TITLE
fix: add auto-reconnection capability to ExchangeConnector

### DIFF
--- a/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/WebSocketExchangeConnector.java
+++ b/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/WebSocketExchangeConnector.java
@@ -98,9 +98,8 @@ public class WebSocketExchangeConnector extends EmbeddedExchangeConnector {
                     .initialize()
                     .doOnComplete(() ->
                         webSocket.closeHandler(v -> {
-                            log.debug("Exchange Connector has been closed with status code '{}'", webSocket.closeStatusCode());
-                            if (!Objects.equals(webSocket.closeStatusCode(), (short) 1000)) {
-                                log.warn("Exchange Connector closed abnormally, reconnecting...");
+                            log.warn("Exchange Connector has been closed with status code '{}'", webSocket.closeStatusCode());
+                            if (shouldReconnect(webSocket)) {
                                 initialize().onErrorComplete().subscribeOn(Schedulers.io()).subscribe();
                             }
                         })
@@ -178,5 +177,11 @@ public class WebSocketExchangeConnector extends EmbeddedExchangeConnector {
             });
         }
         super.addCommandHandlers(commandHandlers);
+    }
+
+    private boolean shouldReconnect(WebSocket webSocket) {
+        return (
+            webSocketConnectorClientFactory.getConfiguration().autoReconnect() || !Objects.equals(webSocket.closeStatusCode(), (short) 1000)
+        );
     }
 }

--- a/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/client/WebSocketClientConfiguration.java
+++ b/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/client/WebSocketClientConfiguration.java
@@ -47,6 +47,7 @@ public class WebSocketClientConfiguration {
     public static final String MAX_WEB_SOCKET_MESSAGE_SIZE_KEY = "connector.ws.maxWebSocketMessageSize";
     public static final int MAX_WEB_SOCKET_MESSAGE_SIZE_DEFAULT = 13107200;
     public static final String ENDPOINTS_KEY = "connector.ws.endpoints";
+    public static final String AUTO_RECONNECT_KEY = "connector.ws.autoReconnect";
     private final IdentifyConfiguration identifyConfiguration;
 
     private List<WebSocketEndpoint> endpoints;
@@ -105,6 +106,14 @@ public class WebSocketClientConfiguration {
 
     public String trustStorePassword() {
         return identifyConfiguration.getProperty(TRUSTSTORE_PASSWORD_KEY);
+    }
+
+    /**
+     * Determines whether auto-reconnection is enabled for the connector.
+     * @return a boolean indicating whether auto-reconnection is enabled (true) or disabled (false)
+     */
+    public boolean autoReconnect() {
+        return identifyConfiguration.getProperty(AUTO_RECONNECT_KEY, Boolean.class, Boolean.FALSE);
     }
 
     /**


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-9710

**Description**

Add auto-reconnection capability to ExchangeConnector

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.8.4-close-channel-when-websocket-connection-close-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/exchange/gravitee-exchange/1.8.4-close-channel-when-websocket-connection-close-SNAPSHOT/gravitee-exchange-1.8.4-close-channel-when-websocket-connection-close-SNAPSHOT.zip)
  <!-- Version placeholder end -->
