### PR TITLE
feat add ability to give the truststore in base64 and handle system p…

### DIFF
--- a/gravitee-exchange-connector/gravitee-exchange-connector-websocket/pom.xml
+++ b/gravitee-exchange-connector/gravitee-exchange-connector-websocket/pom.xml
@@ -71,6 +71,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-vertx</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>provided</scope>

--- a/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/client/WebSocketClientConfiguration.java
+++ b/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/client/WebSocketClientConfiguration.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.exchange.connector.websocket.client;
 
+import static io.gravitee.node.vertx.client.http.VertxHttpClientOptions.DEFAULT_KEEP_ALIVE;
+
 import io.gravitee.exchange.api.configuration.IdentifyConfiguration;
 import io.vertx.core.http.HttpServerOptions;
 import java.util.ArrayList;
@@ -23,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -41,19 +44,28 @@ public class WebSocketClientConfiguration {
     public static final String KEYSTORE_PASSWORD_KEY = "connector.ws.ssl.keystore.password";
     public static final String TRUSTSTORE_TYPE_KEY = "connector.ws.ssl.truststore.type";
     public static final String TRUSTSTORE_PATH_KEY = "connector.ws.ssl.truststore.path";
+    public static final String TRUSTSTORE_CONTENT_KEY = "connector.ws.ssl.truststore.content";
     public static final String TRUSTSTORE_PASSWORD_KEY = "connector.ws.ssl.truststore.password";
+    public static final String TRUSTSTORE_ALIAS_KEY = "connector.ws.ssl.truststore.alias";
     public static final String MAX_WEB_SOCKET_FRAME_SIZE_KEY = "connector.ws.maxWebSocketFrameSize";
     public static final int MAX_WEB_SOCKET_FRAME_SIZE_DEFAULT = 65536;
     public static final String MAX_WEB_SOCKET_MESSAGE_SIZE_KEY = "connector.ws.maxWebSocketMessageSize";
     public static final int MAX_WEB_SOCKET_MESSAGE_SIZE_DEFAULT = 13107200;
     public static final String ENDPOINTS_KEY = "connector.ws.endpoints";
     public static final String AUTO_RECONNECT_KEY = "connector.ws.autoReconnect";
+    private static final String KEEP_ALIVE = "connector.ws.keepAlive";
     private static final String PROXY_ENABLED = "connector.ws.proxy.enabled";
     private static final String PROXY_TYPE = "connector.ws.proxy.type";
     private static final String PROXY_HOST = "connector.ws.proxy.host";
     private static final String PROXY_PORT = "connector.ws.proxy.port";
     private static final String PROXY_USERNAME = "connector.ws.proxy.username";
     private static final String PROXY_PASSWORD = "connector.ws.proxy.password";
+    private static final String PROXY_USE_SYSTEM_PROXY = "connector.ws.proxy.useSystemProxy";
+    private static final String SYSTEM_PROXY_HOST = "system.proxy.host";
+    private static final String SYSTEM_PROXY_PORT = "system.proxy.port";
+    private static final String SYSTEM_PROXY_TYPE = "system.proxy.type";
+    private static final String SYSTEM_PROXY_USERNAME = "system.proxy.username";
+    private static final String SYSTEM_PROXY_PASSWORD = "system.proxy.password";
     private final IdentifyConfiguration identifyConfiguration;
 
     private List<WebSocketEndpoint> endpoints;
@@ -114,6 +126,14 @@ public class WebSocketClientConfiguration {
         return identifyConfiguration.getProperty(TRUSTSTORE_PASSWORD_KEY);
     }
 
+    public String trustStoreContent() {
+        return identifyConfiguration.getProperty(TRUSTSTORE_CONTENT_KEY);
+    }
+
+    public String trustStoreAlias() {
+        return identifyConfiguration.getProperty(TRUSTSTORE_ALIAS_KEY);
+    }
+
     public String proxyType() {
         return identifyConfiguration.getProperty(PROXY_TYPE, String.class, "HTTP");
     }
@@ -134,8 +154,32 @@ public class WebSocketClientConfiguration {
         return identifyConfiguration.getProperty(PROXY_PASSWORD);
     }
 
+    public String systemProxyType() {
+        return identifyConfiguration.environment().getProperty(SYSTEM_PROXY_TYPE, "HTTP");
+    }
+
+    public String systemProxyHost() {
+        return identifyConfiguration.environment().getProperty(SYSTEM_PROXY_HOST);
+    }
+
+    public Integer systemProxyPort() {
+        return identifyConfiguration.environment().getProperty(SYSTEM_PROXY_PORT, Integer.class, 3128);
+    }
+
+    public String systemProxyUsername() {
+        return identifyConfiguration.environment().getProperty(SYSTEM_PROXY_USERNAME);
+    }
+
+    public String systemProxyPassword() {
+        return identifyConfiguration.environment().getProperty(SYSTEM_PROXY_PASSWORD);
+    }
+
     public Boolean isProxyConfigured() {
         return identifyConfiguration.getProperty(PROXY_ENABLED, Boolean.class, Boolean.FALSE);
+    }
+
+    public Boolean proxyUseSystemProxy() {
+        return identifyConfiguration.getProperty(PROXY_USE_SYSTEM_PROXY, Boolean.class, Boolean.FALSE);
     }
 
     /**
@@ -144,6 +188,10 @@ public class WebSocketClientConfiguration {
      */
     public boolean autoReconnect() {
         return identifyConfiguration.getProperty(AUTO_RECONNECT_KEY, Boolean.class, Boolean.FALSE);
+    }
+
+    public boolean keepAlive() {
+        return identifyConfiguration.getProperty(KEEP_ALIVE, Boolean.class, Boolean.TRUE);
     }
 
     /**

--- a/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/test/java/io/gravitee/exchange/connector/websocket/client/WebSocketClientConfigurationTest.java
+++ b/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/test/java/io/gravitee/exchange/connector/websocket/client/WebSocketClientConfigurationTest.java
@@ -1,4 +1,4 @@
-package io.gravitee.exchange.connector.websocket.client;/*
+/*
  * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +13,7 @@ package io.gravitee.exchange.connector.websocket.client;/*
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.gravitee.exchange.connector.websocket.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
@@ -161,6 +162,28 @@ class WebSocketClientConfigurationTest {
         }
 
         @Test
+        void should_return_trust_store_content() {
+            environment.withProperty("%s.connector.ws.ssl.truststore.content".formatted(prefix), "YWJjZGVm");
+            assertThat(cut.trustStoreContent()).isEqualTo("YWJjZGVm");
+        }
+
+        @Test
+        void should_return_null_trust_store_content_without_configuration() {
+            assertThat(cut.trustStoreContent()).isNull();
+        }
+
+        @Test
+        void should_return_trust_store_alias() {
+            environment.withProperty("%s.connector.ws.ssl.truststore.alias".formatted(prefix), "my-alias");
+            assertThat(cut.trustStoreAlias()).isEqualTo("my-alias");
+        }
+
+        @Test
+        void should_return_null_trust_store_alias_without_configuration() {
+            assertThat(cut.trustStoreAlias()).isNull();
+        }
+
+        @Test
         void should_return_max_web_socket_frame_size() {
             environment.withProperty("%s.connector.ws.maxWebSocketFrameSize".formatted(prefix), "123456");
             assertThat(cut.maxWebSocketFrameSize()).isEqualTo(123456);
@@ -215,6 +238,48 @@ class WebSocketClientConfigurationTest {
             assertThat(cut.proxyPort()).isEqualTo(123);
             assertThat(cut.proxyUsername()).isEqualTo("bob");
             assertThat(cut.proxyPassword()).isEqualTo("bob_pwd");
+        }
+
+        @Test
+        void should_return_default_useSystemProxy_without_configuration() {
+            assertThat(cut.proxyUseSystemProxy()).isFalse();
+        }
+
+        @Test
+        void should_return_useSystemProxy_when_configured() {
+            environment.withProperty("%s.connector.ws.proxy.useSystemProxy".formatted(prefix), "true");
+            assertThat(cut.proxyUseSystemProxy()).isTrue();
+        }
+
+        @Test
+        void should_use_system_proxy_configuration_when_enabled() {
+            environment
+                .withProperty("%s.connector.ws.proxy.enabled".formatted(prefix), "true")
+                .withProperty("%s.connector.ws.proxy.useSystemProxy".formatted(prefix), "true")
+                .withProperty("system.proxy.type", "SOCKS5")
+                .withProperty("system.proxy.host", "system-proxy.tld")
+                .withProperty("system.proxy.port", "9999")
+                .withProperty("system.proxy.username", "system-user")
+                .withProperty("system.proxy.password", "system-pwd");
+
+            assertThat(cut.isProxyConfigured()).isTrue();
+            assertThat(cut.proxyUseSystemProxy()).isTrue();
+            assertThat(cut.systemProxyType()).isEqualTo("SOCKS5");
+            assertThat(cut.systemProxyHost()).isEqualTo("system-proxy.tld");
+            assertThat(cut.systemProxyPort()).isEqualTo(9999);
+            assertThat(cut.systemProxyUsername()).isEqualTo("system-user");
+            assertThat(cut.systemProxyPassword()).isEqualTo("system-pwd");
+        }
+
+        @Test
+        void should_return_default_keepAlive_without_configuration() {
+            assertThat(cut.keepAlive()).isTrue();
+        }
+
+        @Test
+        void should_return_keepAlive_when_configured() {
+            environment.withProperty("%s.connector.ws.keepAlive".formatted(prefix), "false");
+            assertThat(cut.keepAlive()).isFalse();
         }
     }
 


### PR DESCRIPTION
**Issue**
https://gravitee.atlassian.net/browse/ARCHI-542

**Description**
Add missing configuration params:
- trust store base 64 content (used gravitee-node-vertx dependency)
- use system proxy
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.10.0-archi-542-improve-hybrid-gateway-configuration-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/exchange/gravitee-exchange/1.10.0-archi-542-improve-hybrid-gateway-configuration-SNAPSHOT/gravitee-exchange-1.10.0-archi-542-improve-hybrid-gateway-configuration-SNAPSHOT.zip)
  <!-- Version placeholder end -->
