### PR TITLE
fix(connector): retain WebSocketClient ref to avoid GC-triggered close

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through sdkman configuration
+# sdkman_auto_env=true
+java=25-tem

--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/channel/AbstractWebSocketChannel.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/channel/AbstractWebSocketChannel.java
@@ -250,6 +250,7 @@ public abstract class AbstractWebSocketChannel implements Channel {
                         ((SingleEmitter<Reply<?>>) replyEmitter).onSuccess(adaptedReply);
                     }
                     if (adaptedReply.stopOnErrorStatus() && adaptedReply.getCommandStatus() == ERROR) {
+                        log.warn("Closing WS after error reply type={} details={}", adaptedReply.getType(), adaptedReply.getErrorDetails());
                         webSocket.close().subscribe();
                     }
                 })
@@ -276,6 +277,7 @@ public abstract class AbstractWebSocketChannel implements Channel {
     @Override
     public Completable close() {
         return Completable.fromRunnable(() -> {
+            log.debug("Channel.close() called");
             webSocket.close((short) 1000).subscribe();
             this.cleanChannel();
         });

--- a/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/WebSocketExchangeConnector.java
+++ b/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/WebSocketExchangeConnector.java
@@ -95,12 +95,20 @@ public class WebSocketExchangeConnector extends EmbeddedExchangeConnector {
                 return connectorChannel
                     .initialize()
                     .doOnComplete(() ->
-                        webSocket.closeHandler(v -> {
-                            log.warn("Exchange Connector has been closed with status code '{}'", webSocket.closeStatusCode());
-                            if (shouldReconnect(webSocket)) {
-                                initialize().onErrorComplete().subscribeOn(Schedulers.io()).subscribe();
-                            }
-                        })
+                        webSocket
+                            .exceptionHandler(throwable -> {
+                                log.warn("An error occurred while handling the WebSocket", throwable);
+                            })
+                            .closeHandler(v -> {
+                                log.warn(
+                                    "Exchange Connector has been closed with status code '{}' - {}",
+                                    webSocket.closeStatusCode(),
+                                    webSocket.closeReason()
+                                );
+                                if (shouldReconnect(webSocket)) {
+                                    initialize().onErrorComplete().subscribeOn(Schedulers.io()).subscribe();
+                                }
+                            })
                     );
             })
             .retryWhen(

--- a/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/WebSocketExchangeConnector.java
+++ b/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/main/java/io/gravitee/exchange/connector/websocket/WebSocketExchangeConnector.java
@@ -60,6 +60,7 @@ public class WebSocketExchangeConnector extends EmbeddedExchangeConnector {
     private final Vertx vertx;
     private final WebSocketConnectorClientFactory webSocketConnectorClientFactory;
     private final ExchangeSerDe exchangeSerDe;
+    private volatile WebSocketClient webSocketClient;
 
     public WebSocketExchangeConnector(
         final ProtocolVersion protocolVersion,
@@ -137,35 +138,50 @@ public class WebSocketExchangeConnector extends EmbeddedExchangeConnector {
             .toSingle()
             .flatMap(webSocketEndpoint -> {
                 log.debug("Trying to connect to the Exchange Controller WebSocket '{}'", webSocketEndpoint.getUrl());
-                WebSocketClient webSocketClient = webSocketConnectorClientFactory.createWebSocketClient(webSocketEndpoint);
-                WebSocketConnectOptions webSocketConnectOptions = new WebSocketConnectOptions()
-                    .setURI(webSocketEndpoint.resolvePath(WebsocketControllerConstants.EXCHANGE_CONTROLLER_PATH))
-                    .addHeader(EXCHANGE_PROTOCOL_HEADER, protocolVersion.version());
-
-                if (webSocketConnectorClientFactory.getConfiguration().headers() != null) {
-                    webSocketConnectorClientFactory.getConfiguration().headers().forEach(webSocketConnectOptions::addHeader);
-                }
-                return webSocketClient
-                    .rxConnect(webSocketConnectOptions)
-                    .doOnSuccess(webSocket -> {
-                        webSocketConnectorClientFactory.resetEndpointRetries();
-                        log.debug("Exchange Connector has successfully connected to the Exchange Controller WebSocket");
+                Completable closePrevious = webSocketClient != null
+                    ? Completable.defer(() -> {
+                        log.debug("Closing previous WebSocketClient before creating a new one (reconnect attempt).");
+                        return webSocketClient.close().onErrorComplete();
                     })
-                    .onErrorResumeNext(throwable -> {
-                        log.error(
-                            "Unable to connect to the Exchange Controller Endpoint {} times, retrying...",
-                            webSocketConnectorClientFactory.endpointRetries(),
-                            throwable
-                        );
-                        // Force the WebSocket client to close after a defect.
+                    : Completable.complete();
+
+                return closePrevious.andThen(
+                    Single.defer(() -> {
+                        webSocketClient = webSocketConnectorClientFactory.createWebSocketClient(webSocketEndpoint);
+                        WebSocketConnectOptions webSocketConnectOptions = new WebSocketConnectOptions()
+                            .setURI(webSocketEndpoint.resolvePath(WebsocketControllerConstants.EXCHANGE_CONTROLLER_PATH))
+                            .addHeader(EXCHANGE_PROTOCOL_HEADER, protocolVersion.version());
+
+                        if (webSocketConnectorClientFactory.getConfiguration().headers() != null) {
+                            webSocketConnectorClientFactory.getConfiguration().headers().forEach(webSocketConnectOptions::addHeader);
+                        }
                         return webSocketClient
-                            .close()
-                            .andThen(
-                                Single.error(
-                                    new WebSocketConnectorException("Unable to connect to Exchange Controller Endpoint", throwable, true)
-                                )
-                            );
-                    });
+                            .rxConnect(webSocketConnectOptions)
+                            .doOnSuccess(webSocket -> {
+                                webSocketConnectorClientFactory.resetEndpointRetries();
+                                log.debug("Exchange Connector has successfully connected to the Exchange Controller WebSocket");
+                            })
+                            .onErrorResumeNext(throwable -> {
+                                log.error(
+                                    "Unable to connect to the Exchange Controller Endpoint {} times, retrying...",
+                                    webSocketConnectorClientFactory.endpointRetries(),
+                                    throwable
+                                );
+                                // Force the WebSocket client to close after a defect.
+                                return webSocketClient
+                                    .close()
+                                    .andThen(
+                                        Single.error(
+                                            new WebSocketConnectorException(
+                                                "Unable to connect to Exchange Controller Endpoint",
+                                                throwable,
+                                                true
+                                            )
+                                        )
+                                    );
+                            });
+                    })
+                );
             });
     }
 

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/channel/primary/PrimaryChannelManagerTest.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/channel/primary/PrimaryChannelManagerTest.java
@@ -48,6 +48,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -153,7 +154,7 @@ class PrimaryChannelManagerTest {
         cut.isPrimaryChannelFor("channelId", "targetId").test().awaitDone(1, TimeUnit.SECONDS).assertValue(false);
     }
 
-    @Test
+    @RepeatedTest(10)
     void should_reelect_after_evicted_primary_channel() {
         AtomicInteger channelElectedEventsCount = new AtomicInteger(0);
         primaryChannelElectedEventTopic.addMessageListener(message -> {
@@ -172,14 +173,11 @@ class PrimaryChannelManagerTest {
             .awaitDone(10, TimeUnit.SECONDS)
             .assertComplete();
 
-        primaryChannelCandidateCache
-            .rxGet("targetId")
-            .test()
-            .awaitDone(10, TimeUnit.SECONDS)
-            .assertValue(strings -> {
-                assertThat(strings).hasSize(2);
-                return true;
-            });
+        await()
+            .atMost(10, TimeUnit.SECONDS)
+            .untilAsserted(() ->
+                assertThat(primaryChannelCandidateCache.get("targetId")).containsExactlyInAnyOrder("channelId", "channelId2")
+            );
 
         cut
             .handleChannelCandidate(ChannelEvent.builder().channelId("channelId").targetId("targetId").active(false).build())


### PR DESCRIPTION
**Description**

Since the migration to Vert.x 5, the Exchange Connector disconnects from
the Exchange Controller roughly 30 seconds after a successful WebSocket
handshake, closing the connection with status code 1000.

Root cause: `Vertx.createWebSocketClient()` in Vert.x 5 returns a
`CleanableWebSocketClient` that registers itself with a `java.lang.ref.Cleaner`.
When the client instance becomes unreachable, the cleaner triggers a
graceful shutdown of the underlying client with a hardcoded 30-second
grace period, which in turn closes every WebSocket opened through it.

In `WebSocketExchangeConnector.connect()`, the `WebSocketClient` was held
only as a local variable. Once `rxConnect` resolved, the returned
`WebSocket` was kept but the `WebSocketClient` wrapper had no strong
reference left. As soon as the JVM garbage-collected it, the cleaner
fired and the 30s timer started, eventually closing a perfectly healthy
connection.

Before Vert.x 5, `vertx.createHttpClient()` did not use a Cleaner, so the
same pattern worked without issue — which is why the regression only
appeared with gravitee-exchange 3.0.0-alpha.2.

Fix: promote `webSocketClient` to an instance field so its lifecycle is
tied to the connector itself. On reconnect, explicitly close the previous
client to avoid leaking resources.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->…down
