### PR TITLE
fix: handle ';;' inside payloads

### DIFF
--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/protocol/v1/V1ProtocolAdapter.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/websocket/protocol/v1/V1ProtocolAdapter.java
@@ -21,6 +21,7 @@ import io.gravitee.exchange.api.websocket.protocol.ProtocolExchange;
 import io.gravitee.exchange.api.websocket.protocol.ProtocolVersion;
 import io.vertx.rxjava3.core.buffer.Buffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 
@@ -59,7 +60,8 @@ public class V1ProtocolAdapter implements ProtocolAdapter {
         ProtocolExchange.Type type = ProtocolExchange.Type.UNKNOWN;
         String exchangeType = null;
         String exchange = null;
-        for (String line : lines) {
+        for (int i = 0; i < lines.length; i++) {
+            final String line = lines[i];
             if (line.startsWith(TYPE_PREFIX)) {
                 try {
                     type = ProtocolExchange.Type.valueOf(extractFrom(line, TYPE_PREFIX));
@@ -69,7 +71,11 @@ public class V1ProtocolAdapter implements ProtocolAdapter {
             } else if (line.startsWith(EXCHANGE_TYPE_PREFIX)) {
                 exchangeType = extractFrom(line, EXCHANGE_TYPE_PREFIX);
             } else if (line.startsWith(EXCHANGE_PREFIX)) {
-                exchange = extractFrom(line, EXCHANGE_PREFIX);
+                // The payload is always the last field; rejoin the remaining segments so a ";;" inside
+                // the payload doesn't truncate the JSON.
+                final String payload = String.join(SEPARATOR, Arrays.copyOfRange(lines, i, lines.length));
+                exchange = extractFrom(payload, EXCHANGE_PREFIX);
+                break;
             }
         }
 

--- a/gravitee-exchange-api/src/test/java/io/gravitee/exchange/api/websocket/channel/AbstractWebSocketChannelTest.java
+++ b/gravitee-exchange-api/src/test/java/io/gravitee/exchange/api/websocket/channel/AbstractWebSocketChannelTest.java
@@ -109,6 +109,46 @@ class AbstractWebSocketChannelTest extends AbstractWebSocketTest {
 
     @ParameterizedTest
     @EnumSource(ProtocolVersion.class)
+    void should_send_command_with_separator_in_payload_and_receive_reply(ProtocolVersion protocolVersion) {
+        ProtocolAdapter protocolAdapter = protocolAdapter(protocolVersion);
+        String content = "case x in a) foo ;; b) bar ;; esac";
+        websocketServerHandler =
+            serverWebSocket ->
+                serverWebSocket.binaryMessageHandler(buffer -> {
+                    ProtocolExchange websocketExchange = protocolAdapter.read(buffer);
+                    Command<?> command = websocketExchange.asCommand();
+                    DummyReply reply = new DummyReply(command.getId(), ((DummyCommand) command).getPayload());
+                    serverWebSocket
+                        .writeBinaryMessage(
+                            protocolAdapter.write(
+                                ProtocolExchange
+                                    .builder()
+                                    .type(ProtocolExchange.Type.REPLY)
+                                    .exchangeType(reply.getType())
+                                    .exchange(reply)
+                                    .build()
+                            )
+                        )
+                        .subscribe();
+                });
+        DummyCommand command = new DummyCommand(new DummyPayload(content));
+        rxWebSocket()
+            .<Reply<?>>flatMap(webSocket -> {
+                Channel webSocketChannel = new SimpleWebSocketChannel(List.of(), List.of(), List.of(), vertx, webSocket, protocolAdapter);
+                return webSocketChannel.initialize().andThen(webSocketChannel.send(command));
+            })
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertValue(reply -> {
+                assertThat(reply).isInstanceOf(DummyReply.class);
+                assertThat(reply.getCommandId()).isEqualTo(command.getId());
+                assertThat(((DummyReply) reply).getPayload().content()).isEqualTo(content);
+                return true;
+            });
+    }
+
+    @ParameterizedTest
+    @EnumSource(ProtocolVersion.class)
     void should_send_command_and_throw_exception_after_timeout(ProtocolVersion protocolVersion) {
         ProtocolAdapter protocolAdapter = protocolAdapter(protocolVersion);
         TestScheduler testScheduler = new TestScheduler();

--- a/gravitee-exchange-api/src/test/java/io/gravitee/exchange/api/websocket/channel/test/DummyPayload.java
+++ b/gravitee-exchange-api/src/test/java/io/gravitee/exchange/api/websocket/channel/test/DummyPayload.java
@@ -17,4 +17,8 @@ package io.gravitee.exchange.api.websocket.channel.test;
 
 import io.gravitee.exchange.api.command.Payload;
 
-public record DummyPayload() implements Payload {}
+public record DummyPayload(String content) implements Payload {
+    public DummyPayload() {
+        this(null);
+    }
+}

--- a/gravitee-exchange-api/src/test/java/io/gravitee/exchange/api/websocket/protocol/v1/V1ProtocolAdapterTest.java
+++ b/gravitee-exchange-api/src/test/java/io/gravitee/exchange/api/websocket/protocol/v1/V1ProtocolAdapterTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.exchange.api.websocket.protocol.v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.exchange.api.command.Command;
+import io.gravitee.exchange.api.command.goodbye.GoodByeCommand;
+import io.gravitee.exchange.api.command.goodbye.GoodByeCommandPayload;
+import io.gravitee.exchange.api.websocket.command.DefaultExchangeSerDe;
+import io.gravitee.exchange.api.websocket.protocol.ProtocolExchange;
+import io.vertx.rxjava3.core.buffer.Buffer;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class V1ProtocolAdapterTest {
+
+    private final V1ProtocolAdapter adapter = new V1ProtocolAdapter(new DefaultExchangeSerDe(new ObjectMapper()));
+
+    private static final String DOC_CONTENT_WITH_SEPARATOR = "case \"$opt\" in\n  d) DEBUG=1 ;;\n  k) DIRECTION=\"$OPTARG\" ;;\nesac";
+
+    @Test
+    void should_round_trip_command_payload_containing_separator() {
+        assertCommandTargetIdRoundTrips(DOC_CONTENT_WITH_SEPARATOR);
+    }
+
+    @Test
+    void should_round_trip_command_payload_with_separated_semicolons() {
+        assertCommandTargetIdRoundTrips(DOC_CONTENT_WITH_SEPARATOR.replace(";;", "; ;"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "a;;b", "a;;b;;c", "a;;;;b", ";;leading", "trailing;;" })
+    void should_round_trip_command_payload_for_separator_variants(final String content) {
+        assertCommandTargetIdRoundTrips(content);
+    }
+
+    @Test
+    void should_round_trip_payload_fragments_that_mimic_field_prefixes() {
+        assertCommandTargetIdRoundTrips("a;;e:b;;t:c");
+    }
+
+    private void assertCommandTargetIdRoundTrips(final String targetId) {
+        final GoodByeCommand command = new GoodByeCommand(GoodByeCommandPayload.builder().targetId(targetId).build());
+
+        final Buffer frame = adapter.write(
+            ProtocolExchange.builder().type(ProtocolExchange.Type.COMMAND).exchangeType(command.getType()).exchange(command).build()
+        );
+        final Command<?> decoded = adapter.read(frame).asCommand();
+
+        assertThat(decoded).isInstanceOf(GoodByeCommand.class);
+        assertThat(((GoodByeCommand) decoded).getPayload().getTargetId()).isEqualTo(targetId);
+    }
+}

--- a/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/test/java/io/gravitee/exchange/connector/websocket/client/WebSocketConnectorClientFactoryTest.java
+++ b/gravitee-exchange-connector/gravitee-exchange-connector-websocket/src/test/java/io/gravitee/exchange/connector/websocket/client/WebSocketConnectorClientFactoryTest.java
@@ -181,8 +181,9 @@ class WebSocketConnectorClientFactoryTest {
                 .awaitDone(30, TimeUnit.SECONDS)
                 .assertError(throwable -> {
                     assertThat(throwable.getCause()).isInstanceOf(SSLHandshakeException.class);
+                    // Use contains rather than isEqualTo: the JDK/TLS stack may prefix the alert (e.g. "(certificate_unknown) ").
                     assertThat(throwable.getCause().getMessage())
-                        .isEqualTo(
+                        .contains(
                             "PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target"
                         );
                     return true;
@@ -283,7 +284,8 @@ class WebSocketConnectorClientFactoryTest {
                 .awaitDone(30, TimeUnit.SECONDS)
                 .assertError(throwable -> {
                     assertThat(throwable.getCause()).isInstanceOf(SSLHandshakeException.class);
-                    assertThat(throwable.getCause().getMessage()).isEqualTo("Received fatal alert: bad_certificate");
+                    // Match on "certificate" only: the exact alert name varies by JDK (bad_certificate vs certificate_required).
+                    assertThat(throwable.getCause().getMessage()).contains("certificate");
                     return true;
                 });
         }


### PR DESCRIPTION
Fixes API promotion hanging (60s `ChannelTimeoutException`) when the promoted content contains `;;`.

Frames join fields with `;;`, but `read()` decoded them with a blind `split(";;")` — so any payload that itself contains `;;` (e.g. a bash `case … ;;` in an API's docs) got truncated and the receiver never replied. `read()` now rejoins the trailing payload field. The wire format is unchanged (backward compatible), but every reader of a `;;` payload needs the bump — the cockpit controller and the APIM connector.

Tests: `V1ProtocolAdapterTest` + an `AbstractWebSocketChannelTest` round-trip. (Second commit is unrelated — relaxed a brittle JDK-wording TLS assertion in `WebSocketConnectorClientFactoryTest`.)

Ticket: https://gravitee.atlassian.net/browse/CJ-4716

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.2-fix-v1-protocol-separator-collision-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/exchange/gravitee-exchange/2.0.2-fix-v1-protocol-separator-collision-SNAPSHOT/gravitee-exchange-2.0.2-fix-v1-protocol-separator-collision-SNAPSHOT.zip)
  <!-- Version placeholder end -->
