### PR TITLE
ci: bump gravitee orb to 6.3.1 to fix artifactory publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@6.0.0
+    gravitee: gravitee-io/gravitee@6.3.1
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)


### PR DESCRIPTION
Bumps the gravitee CircleCI orb 6.0.0 → 6.3.1 on `alpha` to fix the failing `Create tmp version and publish it on Artifactory` step

`ci:`-only change, so it triggers no release — safe to land while 3.0.0 is on hold.

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-ci-bump-gravitee-orb-6-3-1-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/exchange/gravitee-exchange/3.0.0-ci-bump-gravitee-orb-6-3-1-SNAPSHOT/gravitee-exchange-3.0.0-ci-bump-gravitee-orb-6-3-1-SNAPSHOT.zip)
  <!-- Version placeholder end -->
