### PR TITLE
feat: emit the batch when executing with an observer

### DIFF
--- a/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/controller/ExchangeController.java
+++ b/gravitee-exchange-api/src/main/java/io/gravitee/exchange/api/controller/ExchangeController.java
@@ -138,6 +138,14 @@ public interface ExchangeController extends Service<ExchangeController> {
     Completable executeBatch(final Batch batch, final BatchObserver batchObserver);
 
     /**
+     * As {@link ExchangeController#executeBatch(Batch, BatchObserver)} but emits the batch instead of discarding it.
+     * <p>
+     * It is emitted once the first attempt has been replied to, so its commands already carry the outcome of that
+     * attempt. Retries, if any, keep running in the background.
+     */
+    Single<Batch> executeBatchAndObserve(final Batch batch, final BatchObserver batchObserver);
+
+    /**
      * Add a key based {@link BatchObserver} which will be called when any batches with the according key finish
      *
      * @param keyBasedObserver the given will be executed when any batch with the according key finish

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/DefaultExchangeController.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/main/java/io/gravitee/exchange/controller/core/DefaultExchangeController.java
@@ -426,8 +426,13 @@ public class DefaultExchangeController extends AbstractService<ExchangeControlle
 
     @Override
     public Completable executeBatch(final Batch batch, final BatchObserver batchObserver) {
+        return executeBatchAndObserve(batch, batchObserver).ignoreElement();
+    }
+
+    @Override
+    public Single<Batch> executeBatchAndObserve(final Batch batch, final BatchObserver batchObserver) {
         return Completable.fromRunnable(() -> this.idBasedBatchObservers.put(batch.id(), batchObserver))
-            .andThen(executeBatch(batch).ignoreElement())
+            .andThen(executeBatch(batch))
             .doOnError(throwable -> this.idBasedBatchObservers.remove(batch.id()));
     }
 

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/DefaultExchangeControllerTest.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/DefaultExchangeControllerTest.java
@@ -36,6 +36,11 @@ import io.gravitee.node.api.cluster.Member;
 import io.gravitee.node.api.cluster.messaging.Queue;
 import io.gravitee.node.api.cluster.messaging.Topic;
 import io.gravitee.node.management.http.endpoint.ManagementEndpointManager;
+import io.reactivex.rxjava3.core.Completable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -52,6 +57,8 @@ import org.springframework.mock.env.MockEnvironment;
 @ExtendWith(MockitoExtension.class)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class DefaultExchangeControllerTest {
+
+    private static final String BATCH_ID = "a-batch-id";
 
     @Mock
     private ClusterManager clusterManager;
@@ -136,5 +143,36 @@ class DefaultExchangeControllerTest {
         verify(managementEndpointManager, times(8)).register(any());
         cut.stop();
         verify(managementEndpointManager, times(8)).unregister(any());
+    }
+
+    @Test
+    void should_emit_the_batch_when_executing_with_an_observer() throws Exception {
+        givenAnInMemoryBatchStore();
+        cut.start();
+
+        try {
+            cut
+                .executeBatchAndObserve(aBatch(), batch -> Completable.complete())
+                .test()
+                .awaitDone(5, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertValue(batch -> BATCH_ID.equals(batch.id()));
+        } finally {
+            cut.stop();
+        }
+    }
+
+    private void givenAnInMemoryBatchStore() {
+        Map<String, Batch> stored = new HashMap<>();
+        lenient()
+            .when(cache.containsKey(anyString()))
+            .thenAnswer(invocation -> stored.containsKey(invocation.getArgument(0)));
+        lenient()
+            .when(cache.put(anyString(), any(Batch.class)))
+            .thenAnswer(invocation -> stored.put(invocation.getArgument(0), invocation.getArgument(1)));
+    }
+
+    private static Batch aBatch() {
+        return Batch.builder().id(BATCH_ID).key("A_BATCH_KEY").targetId("a-target-id").batchCommands(List.of()).build();
     }
 }

--- a/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/channel/ChannelManagerTest.java
+++ b/gravitee-exchange-controller/gravitee-exchange-controller-core/src/test/java/io/gravitee/exchange/controller/core/channel/ChannelManagerTest.java
@@ -18,6 +18,7 @@ package io.gravitee.exchange.controller.core.channel;
 import static io.gravitee.exchange.controller.core.channel.ChannelManager.CHANNEL_EVENTS_QUEUE;
 import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import io.gravitee.exchange.api.command.Command;
 import io.gravitee.exchange.api.command.CommandHandler;
@@ -318,17 +319,14 @@ class ChannelManagerTest {
             .awaitDone(10, TimeUnit.SECONDS);
         assertThat(vertxTestContext.awaitCompletion(10, TimeUnit.SECONDS)).isTrue();
 
-        cut
-            .channelsMetricsForTarget("targetId")
-            .toList()
-            .test()
-            .awaitDone(10, TimeUnit.SECONDS)
-            .assertValue(channelMetrics -> {
-                assertThat(channelMetrics)
+        // the election event is published before the metric is updated, on another scheduler, so the metric is awaited
+        await()
+            .atMost(10, TimeUnit.SECONDS)
+            .untilAsserted(() ->
+                assertThat(cut.channelsMetricsForTarget("targetId").toList().blockingGet())
                     .extracting(ChannelMetric::id, ChannelMetric::active, ChannelMetric::primary)
-                    .containsOnly(Tuple.tuple("channelId", true, true), Tuple.tuple("channelId2", false, false));
-                return true;
-            });
+                    .containsOnly(Tuple.tuple("channelId", true, true), Tuple.tuple("channelId2", false, false))
+            );
     }
 
     @Test


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/CJ-5090

**Description**

`executeBatch(batch, observer)` drops the batch through `ignoreElement()`, so the caller cannot see how the first attempt went, even though it is already known by then: the commands have been sent and replied to.

`executeBatchAndObserve` returns it instead. Same code path, the `Completable` variant now delegates to it, so nothing changes for existing callers.

Cockpit needs it to tell a client that a deletion was refused, with the reason returned by the installation.

**Additional context**

`ChannelManagerTest.should_return_metrics_for_channel` is fixed along the way: it asserts a metric right after the election event is published, while the metric is updated on another scheduler. It already failed about half the time, and the new tests made it fail every time.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.1.0-feat-execute-batch-and-observe-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/exchange/gravitee-exchange/3.1.0-feat-execute-batch-and-observe-SNAPSHOT/gravitee-exchange-3.1.0-feat-execute-batch-and-observe-SNAPSHOT.zip)
  <!-- Version placeholder end -->
